### PR TITLE
RT #90792: PPI::XSAccessor overwrites indexing of actual source modules on CPAN

### DIFF
--- a/lib/PPI/XSAccessor.pm
+++ b/lib/PPI/XSAccessor.pm
@@ -21,7 +21,8 @@ BEGIN {
 
 # Packages are implemented here in alphabetical order
 
-package PPI::Document;
+package #hide from indexer
+	PPI::Document;
 
 use Class::XSAccessor
 	replace => 1,
@@ -32,7 +33,8 @@ use Class::XSAccessor
 		'scope'
 	];
 
-package PPI::Document::File;
+package #hide from indexer
+	PPI::Document::File;
 
 use Class::XSAccessor
 	replace => 1,
@@ -40,7 +42,8 @@ use Class::XSAccessor
 		filename => 'filename',
 	};
 
-package PPI::Document::Fragment;
+package #hide from indexer
+	PPI::Document::Fragment;
 
 use Class::XSAccessor
 	replace => 1,
@@ -48,7 +51,8 @@ use Class::XSAccessor
 		'scope',
 	];
 
-package PPI::Document::Normalized;
+package #hide from indexer
+	PPI::Document::Normalized;
 
 use Class::XSAccessor
 	replace => 1,
@@ -58,7 +62,8 @@ use Class::XSAccessor
 		'functions' => 'functions',
 	};
 
-package PPI::Element;
+package #hide from indexer
+	PPI::Element;
 
 use Class::XSAccessor
 	replace => 1,
@@ -66,7 +71,8 @@ use Class::XSAccessor
 		'significant',
 	];
 
-package PPI::Exception;
+package #hide from indexer
+	PPI::Exception;
 
 use Class::XSAccessor
 	replace => 1,
@@ -74,7 +80,8 @@ use Class::XSAccessor
 		message => 'message',
 	};
 
-package PPI::Node;
+package #hide from indexer
+	PPI::Node;
 
 use Class::XSAccessor
 	replace => 1,
@@ -82,7 +89,8 @@ use Class::XSAccessor
 		'scope',
 	];
 
-package PPI::Normal;
+package #hide from indexer
+	PPI::Normal;
 
 use Class::XSAccessor
 	replace => 1,
@@ -90,7 +98,8 @@ use Class::XSAccessor
 		'layer' => 'layer',
 	};
 
-package PPI::Statement;
+package #hide from indexer
+	PPI::Statement;
 
 use Class::XSAccessor
 	replace => 1,
@@ -98,7 +107,8 @@ use Class::XSAccessor
 		'__LEXER__normal',
 	];
 
-package PPI::Statement::Compound;
+package #hide from indexer
+	PPI::Statement::Compound;
 
 use Class::XSAccessor
 	replace => 1,
@@ -109,7 +119,8 @@ use Class::XSAccessor
 		'__LEXER__normal',
 	];
 
-package PPI::Statement::Data;
+package #hide from indexer
+	PPI::Statement::Data;
 
 use Class::XSAccessor
 	replace => 1,
@@ -117,7 +128,8 @@ use Class::XSAccessor
 		'_complete',
 	];
 
-package PPI::Statement::End;
+package #hide from indexer
+	PPI::Statement::End;
 
 use Class::XSAccessor
 	replace => 1,
@@ -125,7 +137,8 @@ use Class::XSAccessor
 		'_complete',
 	];
 
-package PPI::Statement::Given;
+package #hide from indexer
+	PPI::Statement::Given;
 
 use Class::XSAccessor
 	replace => 1,
@@ -136,7 +149,8 @@ use Class::XSAccessor
 		'__LEXER__normal',
 	];
 
-package PPI::Token;
+package #hide from indexer
+	PPI::Token;
 
 use Class::XSAccessor
 	replace => 1,


### PR DESCRIPTION
This commits hides the packages in XSAccessor from the CPAN indexer and should thus enable metacpan to link docs and source of PPI modules correctly.
