### PR TITLE
RT 36540 support parsing upper case hex numbers

### DIFF
--- a/lib/PPI/Token/Number.pm
+++ b/lib/PPI/Token/Number.pm
@@ -92,10 +92,10 @@ sub __TOKENIZER__on_char {
 	my $token = $t->{token};
 	if ( $token->{content} =~ /^-?0_*$/ ) {
 		# This could be special
-		if ( $char eq 'x' ) {
+		if ( $char eq 'x' || $char eq 'X' ) {
 			$t->{class} = $t->{token}->set_class( 'Number::Hex' );
 			return 1;
-		} elsif ( $char eq 'b' ) {
+		} elsif ( $char eq 'b' || $char eq 'B' ) {
 			$t->{class} = $t->{token}->set_class( 'Number::Binary' );
 			return 1;
 		} elsif ( $char =~ /\d/ ) {

--- a/lib/PPI/Token/Number/Binary.pm
+++ b/lib/PPI/Token/Number/Binary.pm
@@ -85,7 +85,7 @@ sub __TOKENIZER__on_char {
 
 	if ( $char =~ /[\w\d]/ ) {
 		unless ( $char eq '1' or $char eq '0' ) {
-			# Add a warning if it contains non-hex chars
+			# Add a warning if it contains non-binary chars
 			$t->{token}->{_error} = "Illegal character in binary number '$char'";
 		}
 		return 1;

--- a/lib/PPI/Token/Number/Hex.pm
+++ b/lib/PPI/Token/Number/Hex.pm
@@ -76,7 +76,7 @@ sub __TOKENIZER__on_char {
 	# Allow underscores straight through
 	return 1 if $char eq '_';
 
-	if ( $char =~ /[\da-f]/ ) {
+	if ( $char =~ /[\da-f]/i ) {
 		return 1;
 	}
 

--- a/t/07_token.t
+++ b/t/07_token.t
@@ -11,7 +11,7 @@ BEGIN {
 }
 
 # Execute the tests
-use Test::More tests => 307;
+use Test::More tests => 411;
 use Test::NoWarnings;
 use File::Spec::Functions ':ALL';
 use List::MoreUtils ();
@@ -160,7 +160,7 @@ foreach my $code ( '08', '09', '0778', '0779' ) {
 	is($token->literal, undef, "literal('$code') is undef");
 }
 
-foreach my $code ( '0b2', '0b012' ) {
+foreach my $code ( '0b2', '0B2', '0b012', '0B012' ) {
 	my $T = PPI::Tokenizer->new( \$code );
 	my $token = $T->get_token;
 	isa_ok($token, 'PPI::Token::Number::Binary');
@@ -170,11 +170,49 @@ foreach my $code ( '0b2', '0b012' ) {
 	is($token->literal, undef, "literal('$code') is undef");
 }
 
-foreach my $code ( '0xg', '0x0g' ) {
-	my $T = PPI::Tokenizer->new( \$code );
-	my $token = $T->get_token;
-	isa_ok($token, 'PPI::Token::Number::Hex');
-	isnt("$token", $code, "tokenize bad hex '$code'");
-	ok(!$token->{_error}, 'invalid hexadecimal digit triggers end of token');
-	is($token->literal, 0, "literal('$code') is 0");
+HEX: {
+	my @tests = (
+		# Good hex numbers--entire thing goes in the token
+		{ code => '0x0',        parsed => '0x0', value => 0 },
+		{ code => '0X0',        parsed => '0X0', value => 0 },
+		{ code => '0x1',        parsed => '0x1', value => 1 },
+		{ code => '0x_1',       parsed => '0x_1', value => 1 },
+		{ code => '0x__1',      parsed => '0x__1', value => 1 },
+		{ code => '0x__1_',     parsed => '0x__1_', value => 1 },  # Perl warns, but still includes trailing '_'
+		{ code => '0X1',        parsed => '0X1', value => 1 },
+		{ code => '0xc',        parsed => '0xc', value => 12 },
+		{ code => '0Xc',        parsed => '0Xc', value => 12 },
+		{ code => '0XC',        parsed => '0XC', value => 12 },
+		{ code => '0xbeef',     parsed => '0xbeef', value => 48879 },
+		{ code => '0XbeEf',     parsed => '0XbeEf', value => 48879 },
+		{ code => '0x0e',       parsed => '0x0e', value => 14 },
+		{ code => '0x00000e',   parsed => '0x00000e', value => 14 },
+		{ code => '0x000_00e',  parsed => '0x000_00e', value => 14 },
+		{ code => '0x000__00e', parsed => '0x000__00e', value => 14 },
+		# Bad hex numbers--tokenizing stops when bad digit seen
+		{ code => '0x',    parsed => '0x', value => 0 },
+		{ code => '0X',    parsed => '0X', value => 0 },
+		{ code => '0xg',   parsed => '0x', value => 0 },
+		{ code => '0Xg',   parsed => '0X', value => 0 },
+		{ code => '0XG',   parsed => '0X', value => 0 },
+		{ code => '0x0g',  parsed => '0x0', value => 0 },
+		{ code => '0X0g',  parsed => '0X0', value => 0 },
+		{ code => '0X0G',  parsed => '0X0', value => 0 },
+		{ code => '0x1g',  parsed => '0x1', value => 1 },
+		{ code => '0x1_g', parsed => '0x1_', value => 1 },
+	);
+	foreach my $test ( @tests ) {
+		my $code = $test->{code};
+		my $T = PPI::Tokenizer->new( \$code );
+		my $token = $T->get_token;
+		isa_ok($token, 'PPI::Token::Number::Hex');
+		ok(!$token->{_error}, "no error for '$code' even on invalid digits");
+		is($token->content, $test->{parsed}, "correctly parsed everything expected");
+		if ( !$^V or $^V lt v5.14.0 ) {
+			pass("can't test value on pre-5.14 Perl, which don't accept '0X'");
+		}
+		else {
+			is($token->literal, $test->{value}, "literal('$code') is $test->{value}");
+		}
+	}
 }


### PR DESCRIPTION
Fixed RT 36540 ("0X0D" and the like not parsing as single hex number) as supplied by Kevin Ryde in the ticket, with tests.
