### PR TITLE
RT 75039: don't allow '=CUT' to terminate POD

### DIFF
--- a/lib/PPI/Token/Pod.pm
+++ b/lib/PPI/Token/Pod.pm
@@ -132,7 +132,7 @@ sub __TOKENIZER__on_line_start {
 	# Check the line to see if it is a =cut line
 	if ( $t->{line} =~ /^=(\w+)/ ) {
 		# End of the token
-		$t->_finalize_token if lc $1 eq 'cut';
+		$t->_finalize_token if $1 eq 'cut';
 	}
 
 	0;

--- a/t/ppi_token_pod.t
+++ b/t/ppi_token_pod.t
@@ -12,7 +12,7 @@ BEGIN {
 }
 use PPI;
 
-use Test::More tests => 4;
+use Test::More tests => 8;
 
 {
 	# Create the test fragments
@@ -25,6 +25,20 @@ use Test::More tests => 4;
 	my $merged = PPI::Token::Pod->merge($one, $two);
 	isa_ok( $merged, 'PPI::Token::Pod' );
 	is( $merged->content, "=pod\n\nOne\n\nTwo\n\n=cut\n", 'Merged POD looks ok' );
+}
+
+
+{
+	foreach my $test (
+		[ "=pod\n=cut", [ 'PPI::Token::Pod' ] ],
+		[ "=pod\n=cut\n", [ 'PPI::Token::Pod' ] ],
+		[ "=pod\n=cut\n\n", [ 'PPI::Token::Pod', 'PPI::Token::Whitespace' ] ],
+		[ "=pod\n=Cut\n\n", [ 'PPI::Token::Pod' ] ],  # pod doesn't end, so no whitespace token
+	) {
+		my $T = PPI::Tokenizer->new( \$test->[0] );
+		my @tokens = map { ref $_ } @{ $T->all_tokens };
+		is_deeply( \@tokens, $test->[1], 'all tokens as expected' );
+	}
 }
 
 


### PR DESCRIPTION
Jae Gangemi's fix for https://rt.cpan.org/Public/Bug/Display.html?id=75039 with a test.

Note that the diff of t/ppi_token_pod.t is noisy because that file on master is out of synch with lib/PPI/Token/Pod.pm (at least with my inline2test version 2.213).
