### PR TITLE
Issue 37 capture above 9 misparsed

### DIFF
--- a/lib/PPI/Token/Magic.pm
+++ b/lib/PPI/Token/Magic.pm
@@ -149,7 +149,7 @@ sub __TOKENIZER__on_char {
 		}
 
 		if ( $c =~ /^\$\#\{/ ) {
-			# The $# is actually a case, and { is its block
+			# The $# is actually a cast, and { is its block
 			# Add the current token as the cast...
 			$t->{token} = PPI::Token::Cast->new( '$#' );
 			$t->_finalize_token;
@@ -181,6 +181,13 @@ sub __TOKENIZER__on_char {
 			# control character symbol (e.g. ${^MATCH})
 			$t->{token}->{content} .= $1;
 			$t->{line_cursor}      += length $1;
+		} elsif ( $c =~ /^\$\d+$/ ) {
+			# 2 characters of capture variable at least. See if
+			# it's longer.
+			if ( $t->{line} =~ /\G(\d+)/gc ) {
+				$t->{token}->{content} .= $1;
+				$t->{line_cursor} += length $1;
+			}
 		}
 	}
 

--- a/t/ppi_token_magic.t
+++ b/t/ppi_token_magic.t
@@ -10,7 +10,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 31;
+use Test::More tests => 39;
 use Test::NoWarnings;
 use PPI;
 
@@ -31,6 +31,10 @@ ${^_Bar}[0];            # Magic  @{^_Bar}
 ${^_Baz}{burfle};       # Magic  %{^_Baz}
 $${^MATCH};             # Magic  ${^MATCH}  Dereference of ${^MATCH}
 \${^MATCH};             # Magic  ${^MATCH}
+$0;                     # Magic  $0  -- program being executed
+$0x2;                   # Magic  $0  -- program being executed
+$10;                    # Magic  $10 -- capture variable
+$1100;                  # Magic  $1100 -- capture variable
 END_PERL
 
 	isa_ok( $document, 'PPI::Document' );
@@ -39,7 +43,7 @@ END_PERL
 
 	my $symbols = $document->find( 'PPI::Token::Symbol' );
 
-	is( scalar(@$symbols), 14, 'Found 14 symbols' );
+	is( scalar(@$symbols), 18, 'Found the correct number of symbols' );
 	my $comments = $document->find( 'PPI::Token::Comment' );
 
 	foreach my $token ( @$symbols ) {


### PR DESCRIPTION
A fix for issue #37, wherein the capture variable $10 was being parsed as $1 plus the number 0.

Also removes inline tests from PPI::Token::Magic.
