### PR TITLE
Fix regression and #46

### DIFF
--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -151,16 +151,6 @@ BEGIN {
 	};
 }
 
-# The x operator cannot follow most Perl operators, implying that
-# anything beginning with x following an operator is a word.
-# These are the exceptions.
-my %X_CAN_FOLLOW_OPERATOR = map { $_ => 1 } qw( -- ++ );
-
-# The x operator cannot follow most structure elements, implying that
-# anything beginning with x following a structure element is a word.
-# These are the exceptions.
-my %X_CAN_FOLLOW_STRUCTURE = map { $_ => 1 } qw( } ] \) );
-
 
 sub __TOKENIZER__on_line_start {
 	my $t    = $_[1];
@@ -400,16 +390,8 @@ sub __TOKENIZER__on_char {
 		# 'x ='. An important exception is x followed immediately by
 		# '=>', which makes the x into a bareword.
 		my $remainder = substr $t->{line}, $t->{line_cursor} + 1;
-		if ( $remainder =~ /^(?:\d|(?!(=>|[\w\s])))/ ) {
-			my $prev = $t->_last_significant_token;
-			if (
-				$prev
-				&& (!$prev->isa('PPI::Token::Operator') || $X_CAN_FOLLOW_OPERATOR{$prev})
-				&& (!$prev->isa('PPI::Token::Structure') || $X_CAN_FOLLOW_STRUCTURE{$prev})
-			) {
-				return 'Operator';
-			}
-		}
+		return 'Operator'
+			if $t->_current_x_is_operator and $remainder =~ /^(?:\d|(?!(=>|[\w\s])))/;
 
 		# Otherwise, commit like a normal bareword
 		return PPI::Token::Word->__TOKENIZER__commit($t);

--- a/lib/PPI/Token/Word.pm
+++ b/lib/PPI/Token/Word.pm
@@ -498,7 +498,7 @@ sub __TOKENIZER__commit {
 		return ($t->{line_cursor} >= $t->{line_length}) ? 0
 			: $t->{class}->__TOKENIZER__on_char( $t );
 
-	} elsif ( $OPERATOR{$word} ) {
+	} elsif ( $OPERATOR{$word} && ($word ne 'x' || $t->_current_x_is_operator) ) {
 		# Word operator
 		$token_class = 'Operator';
 

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -92,6 +92,16 @@ BEGIN {
 	$VERSION = '1.216_01';
 }
 
+# The x operator cannot follow most Perl operators, implying that
+# anything beginning with x following an operator is a word.
+# These are the exceptions.
+my %X_CAN_FOLLOW_OPERATOR = map { $_ => 1 } qw( -- ++ );
+
+# The x operator cannot follow most structure elements, implying that
+# anything beginning with x following a structure element is a word.
+# These are the exceptions.
+my %X_CAN_FOLLOW_STRUCTURE = map { $_ => 1 } qw( } ] \) );
+
 
 
 
@@ -754,6 +764,19 @@ sub _opcontext {
 
 	# Otherwise, we don't know
 	return ''
+}
+
+# Assuming we are currently parsing the word 'x', return true
+# if previous tokens imply the x is an operator, false otherwise.
+sub _current_x_is_operator {
+	my $self = shift;
+
+	my $prev = $self->_last_significant_token;
+	return 
+		$prev
+		&& (!$prev->isa('PPI::Token::Operator') || $X_CAN_FOLLOW_OPERATOR{$prev})
+		&& (!$prev->isa('PPI::Token::Structure') || $X_CAN_FOLLOW_STRUCTURE{$prev})
+	;
 }
 
 1;

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -11,7 +11,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 395;
+use Test::More tests => 398;
 use Test::NoWarnings;
 use PPI;
 
@@ -280,6 +280,24 @@ OPERATOR_X: {
 			],
 		},
 		{
+			desc => 'x right of => is not an operator',
+			code => '1=>x',
+			expected => [
+				'PPI::Token::Number' => '1',
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Word' => 'x',
+			],
+		},
+		{
+			desc => 'xor right of => is an operator',
+			code => '1=>xor',
+			expected => [
+				'PPI::Token::Number' => '1',
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Operator' => 'xor',
+			],
+		},
+		{
 			desc => 'RT 37892: list as arg to x operator 1',
 			code => '(1) x 6',
 			expected => [
@@ -316,6 +334,18 @@ OPERATOR_X: {
 				'PPI::Token::Structure' => '(',
 				'PPI::Statement::Expression' => '1',
 				'PPI::Token::Number' => '1',
+				'PPI::Token::Structure' => ')',
+				'PPI::Token::Operator' => 'x',
+				'PPI::Token::Number' => '6',
+			],
+		},
+		{
+			desc => 'RT 37892: x following function is operator',
+			code => 'foo()x6',
+			expected => [
+				'PPI::Token::Word' => 'foo',
+				'PPI::Structure::List' => '()',
+				'PPI::Token::Structure' => '(',
 				'PPI::Token::Structure' => ')',
 				'PPI::Token::Operator' => 'x',
 				'PPI::Token::Number' => '6',


### PR DESCRIPTION
Add tests for cases mentioned in https://rt.cpan.org/Public/Bug/Display.html?id=37892 that are already fixed in 1.215.
Fix regression in x operator handling that caused words like 'x86_convert' in $obj->x86_convert() to be split into 'x' operator + number 86 + 'convert'.
Fix #46 -  '1=>x' being parsed as having the x operator.
