### PR TITLE
Fix up PPI::Token::insert_{after,before}.

### DIFF
--- a/lib/PPI/Token.pm
+++ b/lib/PPI/Token.pm
@@ -172,7 +172,7 @@ sub content {
 sub insert_before {
 	my $self    = shift;
 	my $Element = _INSTANCE(shift, 'PPI::Element')  or return undef;
-	if ( $Element->isa('PPI::Structure') ) {
+	if ( $Element->isa('PPI::Statement') ) {
 		return $self->__insert_before($Element);
 	} elsif ( $Element->isa('PPI::Token') ) {
 		return $self->__insert_before($Element);
@@ -184,7 +184,7 @@ sub insert_before {
 sub insert_after {
 	my $self    = shift;
 	my $Element = _INSTANCE(shift, 'PPI::Element') or return undef;
-	if ( $Element->isa('PPI::Structure') ) {
+	if ( $Element->isa('PPI::Statement') ) {
 		return $self->__insert_after($Element);
 	} elsif ( $Element->isa('PPI::Token') ) {
 		return $self->__insert_after($Element);


### PR DESCRIPTION
I stumbled across this while trying to make
Dist::Zilla::Plugin::PkgVersion work better with perlcritic.  [More
info here](https://github.com/rjbs/Dist-Zilla/pull/168).

The comments for PPI::Token::insert_{after,before} say that they may
only insert statements, but the code inexplicably requires
PPI::Structures.

Requiring a Statement a) seems reasonable to me (but...) and b) makes my use case easier.

This commit makes the code match the comment.

The tests in t still pass.

I'm hoping for feedback from folks wise.

PPI::Statement's code and comment require that a Statement be inserted.  PPI::Structure's code and comments require a Structure.

PPI::Token is the only one who's code and comments don't match.  It's possible that a better fix is to fix the comment.
