### PR TITLE
Unescape results from PPI::Token::QuoteLike::Words::literal #124

### DIFF
--- a/lib/PPI/Token/QuoteLike/Words.pm
+++ b/lib/PPI/Token/QuoteLike/Words.pm
@@ -42,7 +42,7 @@ BEGIN {
 
 =head2 literal
 
-Returns the words contained.  Note that this method does not check the
+Returns the words contained as a list.  Note that this method does not check the
 context that the token is in; it always returns the list and not merely
 the last element if the token is in scalar context.
 
@@ -50,12 +50,21 @@ the last element if the token is in scalar context.
 
 sub literal {
 	my $self    = shift;
-	my $section = $self->{sections}->[0];
-	return split ' ', substr(
-		$self->{content},
-		$section->{position},
-		$section->{size},
-	);
+
+	my @words;
+
+	my $content = $self->_section_content(0);
+	if ( defined $content ) {
+		# Undo backslash escaping of '\', the left delimiter,
+		# and the right delimiter.  The right delimiter will
+		# only exist with paired delimiters: qw() qw[] qw<> qw{}.
+		my ( $left, $right ) = ( $self->_delimiters, '', '' );
+		$content =~ s/\\([\Q$left$right\\\E])/$1/g;
+
+		@words = split ' ', $content;
+	}
+
+	return @words;
 }
 
 1;

--- a/lib/PPI/Token/_QuoteEngine/Full.pm
+++ b/lib/PPI/Token/_QuoteEngine/Full.pm
@@ -32,7 +32,7 @@ BEGIN {
 		's'   => { operator => 's',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 		'tr'  => { operator => 'tr',  braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 
-		# Y is the little used variant of tr
+		# Y is the little-used variant of tr
 		'y'   => { operator => 'y',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 
 		'/'   => { operator => undef, braced => 0,     separator => '/',   _sections => 1, modifiers => 1 },

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -739,7 +739,7 @@ my %OBVIOUS_CONTENT = (
 
 my %USUALLY_FORCES = map { $_ => 1 } qw( sub package use no );
 
-# Try to determine operator/operand context, is possible.
+# Try to determine operator/operand context, if possible.
 # Returns "operator", "operand", or "" if unknown.
 sub _opcontext {
 	my $self   = shift;

--- a/t/ppi_token_quotelike_words.t
+++ b/t/ppi_token_quotelike_words.t
@@ -10,48 +10,144 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 13;
+use Test::More tests => 1941;
+use Test::Deep;
 use Test::NoWarnings;
 use PPI;
 
 
 LITERAL: {
-	my $empty_list_document = PPI::Document->new(\<<'END_PERL');
-qw//
-qw/    /
-END_PERL
+	my $bs = '\\'; # a single backslash character
 
-	isa_ok( $empty_list_document, 'PPI::Document' );
-	my $empty_list_tokens =
-		$empty_list_document->find('PPI::Token::QuoteLike::Words');
-	is( scalar @{$empty_list_tokens}, 2, 'Found expected empty word lists.' );
-	foreach my $token ( @{$empty_list_tokens} ) {
-		my @literal = $token->literal;
-		is( scalar @literal, 0, qq<No elements for "$token"> );
-	}
+	# empty
+	permute_test( [], '/', '/', [] );
+	permute_test( [], '"', '"', [] );
+	permute_test( [], "'", "'", [] );
+	permute_test( [], '(', ')', [] );
+	permute_test( [], '{', '}', [] );
+	permute_test( [], '[', ']', [] );
+	permute_test( [], '<', '>', [] );
 
-	my $non_empty_list_document = PPI::Document->new(\<<'END_PERL');
-qw/foo bar baz/
-qw/  foo bar baz  /
-qw {foo bar baz}
-END_PERL
-	my @expected = qw/ foo bar baz /;
+	# words
+	permute_test( ['a', 'b', 'c'],      '/', '/', ['a', 'b', 'c'] );
+	permute_test( ['a,', 'b', 'c,'],    '/', '/', ['a,', 'b', 'c,'] );
+	permute_test( ['a', ',', '#', 'c'], '/', '/', ['a', ',', '#', 'c'] );
+	permute_test( ['f_oo', 'b_ar'],     '/', '/', ['f_oo', 'b_ar'] );
 
-	isa_ok( $non_empty_list_document, 'PPI::Document' );
-	my $non_empty_list_tokens =
-		$non_empty_list_document->find('PPI::Token::QuoteLike::Words');
-	is(
-		scalar(@$non_empty_list_tokens),
-		3,
-		'Found expected non-empty word lists.',
-	);
-	foreach my $token ( @$non_empty_list_tokens ) {
-		my $literal = $token->literal;
-		is(
-			$literal,
-			scalar @expected,
-			qq<Scalar context literal() returns the list for "$token">,
-		);
-		is_deeply( [ $token->literal ], \@expected, '->literal matches expected' );
-	}
+	# it's allowed for both delims to be closers
+	permute_test( ['a'], ')', ')', ['a'] );
+	permute_test( ['a'], '}', '}', ['a'] );
+	permute_test( ['a'], ']', ']', ['a'] );
+	permute_test( ['a'], '>', '>', ['a'] );
+
+	# containing things that sometimes are delimiters
+	permute_test( ['/'],        '(', ')', ['/'] );
+	permute_test( ['//'],       '(', ')', ['//'] );
+	permute_test( ['qw()'],     '(', ')', ['qw()'] );
+	permute_test( ['qw', '()'], '(', ')', ['qw', '()'] );
+	permute_test( ['qw//'],     '(', ')', ['qw//'] );
+
+	# nested delimiters
+	permute_test( ['()'],           '(', ')', ['()'] );
+	permute_test( ['{}'],           '{', '}', ['{}'] );
+	permute_test( ['[]'],           '[', ']', ['[]'] );
+	permute_test( ['<>'],           '<', '>', ['<>'] );
+	permute_test( ['((', ')', ')'], '(', ')', ['((', ')', ')'] );
+	permute_test( ['{{', '}', '}'], '{', '}', ['{{', '}', '}'] );
+	permute_test( ['[[', ']', ']'], '[', ']', ['[[', ']', ']'] );
+	permute_test( ['<<', '>', '>'], '<', '>', ['<<', '>', '>'] );
+
+	# escaped opening and closing
+	permute_test( ["$bs)"],   '(', ')', [')'] );
+	permute_test( ["$bs("],   '(', ')', ['('] );
+	permute_test( ["$bs}"],   '{', '}', ['}'] );
+	permute_test( ["${bs}{"], '{', '}', ['{'] );
+	permute_test( ["$bs]"],   '[', ']', [']'] );
+	permute_test( ["${bs}["], '[', ']', ['['] );
+	permute_test( ["$bs<"],   '<', '>', ['<'] );
+	permute_test( ["$bs>"],   '<', '>', ['>'] );
+	permute_test( ["$bs/"],   '/', '/', ['/'] );
+	permute_test( ["$bs'"],   "'", "'", ["'"] );
+	permute_test( [$bs.'"'],  '"', '"', ['"'] );
+	# alphanum delims have to be separated from qw
+	assemble_and_run( " ",  ['a', "${bs}1"], '1', " ",  " ",  '1', ['a', '1'] );
+	assemble_and_run( " ",  ["${bs}a"],      'a', " ",  " ",  'a', ['a'] );
+	assemble_and_run( "\n", ["${bs}a"],      'a', "\n", "\n", 'a', ['a'] );
+	# '#' delims cannot be separated from qw
+	assemble_and_run( '',  ['a'],      '#', '',   ' ',  '#', ['a'] );
+	assemble_and_run( '',  ['a'],      '#', ' ',  ' ',  '#', ['a'] );
+	assemble_and_run( '',  ["$bs#"],   '#', '',   ' ',  '#', ['#'] );
+	assemble_and_run( '',  ["$bs#"],   '#', ' ',  ' ',  '#', ['#'] );
+	assemble_and_run( '',  ["$bs#"],   '#', "\n", "\n", '#', ['#'] );
+	# a single backslash represents itself
+	assemble_and_run( '',  [$bs],  '(', ' ',  ' ', ')', [$bs] );
+	assemble_and_run( '',  [$bs],  '(', "\n", ' ', ')', [$bs] );
+	# a double backslash represents itself
+	assemble_and_run( '',  ["$bs$bs"],  '(', ' ',  ' ', ')', [$bs] );
+	assemble_and_run( '',  ["$bs$bs"],  '(', "\n", ' ', ')', [$bs] );
+	# even backslash can be a delimiter, in when it is, backslashes
+	# can't be embedded or escaped.
+	assemble_and_run( '',   [],    $bs, ' ',  ' ',  $bs, [] );
+	assemble_and_run( '',   [],    $bs, "\n", "\n", $bs, [] );
+	assemble_and_run( '',   ['a'], $bs, '',   ' ',  $bs, ['a'] );
+	assemble_and_run( ' ',  ['a'], $bs, '',   ' ',  $bs, ['a'] );
+	assemble_and_run( "\n", ['a'], $bs, '',   ' ',  $bs, ['a'] );
 }
+
+
+sub permute_test {
+	my $words_in = shift;
+	my $left_delim = shift;
+	my $right_delim = shift;
+	my $expected = shift;
+
+	assemble_and_run( "",  $words_in, $left_delim, "", " ",  $right_delim, $expected );
+	assemble_and_run( "",  $words_in, $left_delim, "", "\t", $right_delim, $expected );
+	assemble_and_run( "",  $words_in, $left_delim, "", "\n", $right_delim, $expected );
+	assemble_and_run( "",  $words_in, $left_delim, "", "\f", $right_delim, $expected );
+
+	assemble_and_run( "",  $words_in, $left_delim, " ", " ",   $right_delim, $expected );
+	assemble_and_run( "",  $words_in, $left_delim, "\t", "\t", $right_delim, $expected );
+	assemble_and_run( "",  $words_in, $left_delim, "\n", "\n", $right_delim, $expected );
+	assemble_and_run( "",  $words_in, $left_delim, "\f", "\f", $right_delim, $expected );
+
+	assemble_and_run( " ",  $words_in, $left_delim, " ", " ",   $right_delim, $expected );
+	assemble_and_run( "\t", $words_in, $left_delim, "\t", "\t", $right_delim, $expected );
+	assemble_and_run( "\n", $words_in, $left_delim, "\n", "\n", $right_delim, $expected );
+	assemble_and_run( "\f", $words_in, $left_delim, "\f", "\f", $right_delim, $expected );
+
+	return;
+}
+
+
+sub assemble_and_run {
+	my $pre_left_delim = shift;
+	my $words_in = shift;
+	my $left_delim = shift;
+	my $delim_padding = shift;
+	my $word_separator = shift;
+	my $right_delim = shift;
+	my $expected = shift;
+
+	my $code = "qw$pre_left_delim$left_delim$delim_padding" . join(' ', @$words_in) . "$delim_padding$right_delim";
+	execute_test( $code, $expected, $code );
+
+	return;
+}
+
+
+sub execute_test {
+	my $code = shift;
+	my $expected = shift;
+	my $msg = shift;
+
+	my $d = PPI::Document->new( \$code );
+	isa_ok( $d, 'PPI::Document', $msg );
+	my $found = $d->find( 'PPI::Token::QuoteLike::Words' ) || [];
+	is( @$found, 1, "$msg - exactly one qw" );
+	is( $found->[0]->content, $code, "$msg content()" );
+	is_deeply( [ $found->[0]->literal() ], $expected, "$msg literal()"  );
+
+	return;
+}
+


### PR DESCRIPTION
PPI::Token::QuoteLike::Words->literal() was not un-escaping the words, meaning that the caller would get words like ")" and have to do the unescaping. The method's documentation does not address unescaping, but unescaping seems like the right thing to do.

Lots more test coverage, including nested delimiters and whitespace other than spaces.
