### PR TITLE
use xdigit character class -- fix #100

### DIFF
--- a/lib/PPI/Cache.pm
+++ b/lib/PPI/Cache.pm
@@ -268,7 +268,7 @@ sub _md5hex {
 	my $it     = _SCALAR($_[0])
 		? PPI::Util::md5hex(${$_[0]})
 		: $_[0];
-	return (defined $it and ! ref $it and $it =~ /^[a-f0-9]{32}\z/si)
+	return (defined $it and ! ref $it and $it =~ /^[[:xdigit:]]{32}\z/s)
 		? lc $it
 		: undef;
 }

--- a/lib/PPI/Token/Number/Hex.pm
+++ b/lib/PPI/Token/Number/Hex.pm
@@ -76,7 +76,7 @@ sub __TOKENIZER__on_char {
 	# Allow underscores straight through
 	return 1 if $char eq '_';
 
-	if ( $char =~ /[\da-f]/i ) {
+	if ( $char =~ /[[:xdigit:]]/ ) {
 		return 1;
 	}
 

--- a/t/19_selftesting.t
+++ b/t/19_selftesting.t
@@ -84,7 +84,7 @@ is_deeply( $bad, [ 'Bad::Class1', 'Bad::Class2', 'Bad::Class3', 'Bad::Class4' ],
 foreach my $file ( @files ) {
 	# MD5 the raw file
 	my $md5a = PPI::Util::md5hex_file($file);
-	like( $md5a, qr/^[0-9a-f]{32}\z/, 'md5hex_file ok' );
+	like( $md5a, qr/^[[:xdigit:]]{32}\z/, 'md5hex_file ok' );
 
 	# Load the file
 	my $Document = PPI::Document->new($file);


### PR DESCRIPTION
I'm finding it difficult to add meaningful tests to cover this behavior, since Unicode digits that match \d, e.g., cause PPI to throw exceptions in PPI::Token::Whitespace.
