### PR TITLE
Add byte offsets for Tokens

### DIFF
--- a/lib/PPI/Normal.pm
+++ b/lib/PPI/Normal.pm
@@ -194,6 +194,11 @@ sub process {
 		&{"$function"}( $self->{Document} );
 	}
 
+	# Reset token offsets as they are not valid anymore
+	for my $token ($self->{Document}->tokens) {
+		$token->{_byte_start} = -1;
+	}
+
 	# Create the normalized Document object
 	my $Normalized = PPI::Document::Normalized->new(
 		Document  => $self->{Document},

--- a/lib/PPI/Token.pm
+++ b/lib/PPI/Token.pm
@@ -25,6 +25,8 @@ use Params::Util   qw{_INSTANCE};
 use PPI::Element   ();
 use PPI::Exception ();
 
+require bytes;
+
 use vars qw{$VERSION @ISA};
 BEGIN {
 	$VERSION = '1.220';
@@ -83,7 +85,10 @@ use PPI::Token::Unknown               ();
 # Constructor and Related
 
 sub new {
-	bless { content => (defined $_[1] ? "$_[1]" : '') }, $_[0];
+	bless {
+		content     => (defined $_[1] ? "$_[1]" : ''),
+		_byte_start => (defined $_[2] ? $_[2] : -1),
+	}, $_[0];
 }
 
 sub set_class {
@@ -158,6 +163,56 @@ The C<length> method returns the length of the string in a Token.
 sub length { CORE::length($_[0]->{content}) }
 
 
+=pod
+
+=head2 byte_span
+
+Returns an arrayref with zero-based offsets of the first and last bytes of that
+Token.
+
+Offsets are absolute byte positions within a Document, meaning the very first
+byte of the first token is always at position zero and the last byte of the
+last token is always at position I<document size in bytes - 1>.
+
+Example:
+
+	my $Document = PPI::Document->new( \'my $var = 42;' );
+	[ map($_->byte_span, $Document->tokens) ];
+
+will produce the following:
+
+	[
+		[0, 2],   # my
+		[3, 3],   # whitespace
+		[4, 7],   # $var
+		[8, 8],   # whitespace
+		[9, 9],   # =
+		[10, 10], # whitespace
+		[11, 12], # 42
+		[13, 13], # ;
+	]
+
+Returns C<undef> for tokens with unknown position (e.g. tokens not attached to
+a Document).
+
+For some token types computing a byte span is not supported. Currently there's
+only one unsupported type: L<PPI::Token::HereDoc>.
+Tokens of that type still contribute to the total size of the Document but do
+not have a span of their own (meaning this method will return C<undef>).
+
+Normalising a Document invalidates offsets of all tokens, making this method
+return C<undef>.
+
+B<NOTE>: as the method name suggests, offsets are caclulated in bytes, not
+characters.
+
+=cut
+
+sub byte_span {
+	my $start = $_[0]->{_byte_start};
+	return undef if $start < 0;
+	[ $start, $start + bytes::length($_[0]->{content}) - 1 ];
+}
 
 
 

--- a/lib/PPI/Token/HereDoc.pm
+++ b/lib/PPI/Token/HereDoc.pm
@@ -93,7 +93,7 @@ BEGIN {
 	@ISA     = 'PPI::Token';
 }
 
-
+require bytes;
 
 
 
@@ -214,6 +214,16 @@ sub __TOKENIZER__on_char {
 			# when we are re-assembling the file
 			$token->{_terminator_line} = $line;
 
+			# Actual content and terminator are not included when
+			# computing a HereDoc's byte length so we need to stash
+			# it so that we can manually fixup offsets later
+			#
+			# A line may contain multiple heredocs and we need them
+			# all so we're adding the length, not overwriting it
+			$t->{__current_heredoc_byte_length} +=
+				bytes::length(join("", @heredoc)) +
+				bytes::length($line);
+
 			# The HereDoc is now fully parsed
 			return $t->_finalize_token->__TOKENIZER__on_char( $t );
 		}
@@ -250,6 +260,12 @@ sub __TOKENIZER__on_char {
 
 	# The HereDoc is not fully parsed
 	$t->_finalize_token->__TOKENIZER__on_char( $t );
+}
+
+# override byte_span() from the parent class because
+# for heredocs byte offsets are undefined
+sub byte_span {
+    return undef;
 }
 
 1;

--- a/t/08_regression.t
+++ b/t/08_regression.t
@@ -69,6 +69,7 @@ SCOPE: {
 	# Check the regexp matches what we would expect (specifically
 	# the fine details about the sections.
 	my $expected = {
+		_byte_start => 0,
 		_sections => 2,
 		braced    => 1,
 		content   => 's {foo} <bar>i',
@@ -99,6 +100,7 @@ SCOPE: {
 
 	# Check the internal details as before
 	my $expected = {
+		_byte_start => 0,
 		_sections => 2,
 		_error    => "No second section of regexp, or does not start with a balanced character",
 		braced    => 1,

--- a/t/29_token_offsets.t
+++ b/t/29_token_offsets.t
@@ -1,0 +1,212 @@
+#!/usr/bin/perl
+
+use utf8;
+use open qw(:std :utf8);
+use strict;
+BEGIN {
+	no warnings 'once';
+	$| = 1;
+	$PPI::XS_DISABLE = 1;
+	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
+}
+
+use Test::More tests => 12;
+use Test::NoWarnings;
+use PPI;
+
+my @tests = (
+[
+	"use strict;",
+	[
+		[0, 2],   # use
+		[3, 3],   # whitespace
+		[4, 9],   # strict
+		[10, 10], # ;
+	],
+],
+[
+	"use strict;\nuse warnings;",
+	[
+		[0, 2],   # use
+		[3, 3],   # whitespace
+		[4, 9],   # strict
+		[10, 10], # ;
+		[11, 11], # newline
+		[12, 14], # use
+		[15, 15], # whitespace
+		[16, 23], # warnings
+		[24, 24], # ;
+	],
+],
+[
+	"my \$var = <<EOT;\nheredocs <3\nEOT\n",
+	[
+		[0, 1],   # my
+		[2, 2],   # whitespace
+		[3, 6],   # $var
+		[7, 7],   # whitespace
+		[8, 8],   # =
+		[9, 9],   # whitespace
+		undef,    # heredoc
+		[15, 15], # ;
+		[16, 16], # newline
+	],
+],
+[
+	"foobar(<<EOT);\nheredocs <3\nEOT\n",
+	[
+		[0, 5],   # foobar
+		[6, 6],   # (
+		undef,    # heredoc
+		[12, 12], # )
+		[13, 13], # ;
+		[14, 14], # newline
+	],
+],
+[
+	"foobar(<<EOT);\nheredocs <3\nEOT\nmy \$var = <<EOT;\nheredocs <3\nEOT\n",
+	[
+		[0, 5],   # foobar
+		[6, 6],   # (
+		undef,    # heredoc
+		[12, 12], # )
+		[13, 13], # ;
+		[14, 14], # newline
+		[31, 32], # my
+		[33, 33], # whitespace
+		[34, 37], # $var
+		[38, 38], # whitespace
+		[39, 39], # =
+		[40, 40], # whitespace
+		undef,    # heredoc
+		[46, 46], # ;
+		[47, 47], # newline
+	],
+],
+[
+	"foobar(<<EOT, \$var1);\nheredocs <3\nEOT\nmy \$var2;",
+	[
+		[0, 5],   # foobar
+		[6, 6],   # (
+		undef,    # heredoc
+		[12, 12], # ,
+		[13, 13], # whitespace
+		[14, 18], # $var1
+		[19, 19], # )
+		[20, 20], # ;
+		[21, 21], # \n
+		[38, 39], # my
+		[40, 40], # whitespace
+		[41, 45], # $var2
+		[46, 46], # ;
+	],
+],
+[
+	"foobar(<<EOT1, <<EOT2);\nheredocs <3\nEOT1\nheredocs <3\nEOT2\nmy \$var;",
+	[
+		[0, 5],   # foobar
+		[6, 6],   # (
+		undef,    # heredoc
+		[13, 13], # ,
+		[14, 14], # whitespace
+		undef,    # heredoc
+		[21, 21], # )
+		[22, 22], # ;
+		[23, 23], # \n
+		[58, 59], # my
+		[60, 60], # whitespace
+		[61, 64], # $var
+		[65, 65], # ;
+	],
+],
+[
+	"foobar(<<EOT1, \$var, <<EOT2);\nheredocs <3\nEOT1\nheredocs <3\nEOT2\nmy \$var2;",
+	[
+		[0, 5],   # foobar
+		[6, 6],   # (
+		undef,    # heredoc
+		[13, 13], # ,
+		[14, 14], # whitespace
+		[15, 18], # $var
+		[19, 19], # ,
+		[20, 20], # whitespace
+		undef,    # heredoc
+		[27, 27], # )
+		[28, 28], # ;
+		[29, 29], # \n
+		[64, 65], # my
+		[66, 66], # whitespace
+		[67, 71], # $var2
+		[72, 72], # ;
+	],
+],
+[
+	"foobar(<<EOT1, \$var, <<EOT2, \$var2);\nheredocs <3\nEOT1\nheredocs <3\nEOT2\nmy \$var3;",
+	[
+		[0, 5],   # foobar
+		[6, 6],   # (
+		undef,    # heredoc
+		[13, 13], # ,
+		[14, 14], # whitespace
+		[15, 18], # $var
+		[19, 19], # ,
+		[20, 20], # whitespace
+		undef,    # heredoc
+		[27, 27], # whitespace
+		[28, 28], # comma
+		[29, 33], # $var2
+		[34, 34], # )
+		[35, 35], # ;
+		[36, 36], # \n
+		[71, 72], # my
+		[73, 73], # whitespace
+		[74, 78], # $var3
+		[79, 79], # ;
+	],
+],
+[
+	"my \@lines = <<EOT =~ /regex/;\nheredocs <3\nEOT\n",
+	[
+		[0, 1],   # my
+		[2, 2],   # whitespace
+		[3, 8],   # @lines
+		[9, 9],   # whitespace
+		[10, 10], # =
+		[11, 11], # whitespace
+		undef,    # heredoc
+		[17, 17], # whitespace
+		[18, 19], # =~
+		[20, 20], # whitespace
+		[21, 27], # /regex/
+		[28, 28], # ;
+		[29, 29], # \n
+	],
+],
+[
+	"my \$var = 'こんにちは';",
+	[
+		[0, 1],   # my
+		[2, 2],   # whitespace
+		[3, 6],   # $var
+		[7, 7],   # whitespace
+		[8, 8],   # =
+		[9, 9],   # whitespace
+		[10, 26], # 'こんにちは'
+		[27, 27], # ;
+	],
+],
+);
+
+for my $t (@tests) {
+	my $Document = PPI::Document->new( \$t->[0] );
+
+	my $ok = is_deeply(
+		[ map($_->byte_span, $Document->tokens) ],
+		$t->[1],
+		"Tokens have correct byte spans"
+	);
+
+	unless($ok) {
+		diag($t->[0]);
+	}
+}


### PR DESCRIPTION
This patch adds a new method that returns positions of the first and the last bytes of a Token (byte span).
It comes in handy e.g. when building smart code viewer apps (`PPI::Element->location()` is not precise enough) or working with code analysis libraries (all libraries I'm aware of require byte offsets).
