### PR TITLE
Quash uninitialized errors in t/07_token.t.

### DIFF
--- a/t/07_token.t
+++ b/t/07_token.t
@@ -109,6 +109,7 @@ SCOPE: {
 		like($err, qr/No digits found for (binary|hexadecimal) literal/,
 			 "$] dies on incomplete binary/hexadecimal literals")
 			if $underscore_incompatible;
+		no warnings qw{ uninitialized };
 		cmp_ok($token->literal, '==', $err ? undef : $literal,
 			   "literal('$code'), eval error: " . ($err || "none"));
 	}


### PR DESCRIPTION
Since the code involved is a deliberate numeric comparison to undef, I
have taken the coward's way out and just done a

    no warnings qw{ uninitialized };

I have not created a new scope for this because the code involved was
the last statement in its scope.