### PR TITLE
Preserve whitespace in signatures

### DIFF
--- a/lib/PPI/Token/Prototype.pm
+++ b/lib/PPI/Token/Prototype.pm
@@ -59,7 +59,7 @@ sub __TOKENIZER__on_char {
 
 	# Suck in until we find the closing paren (or the end of line)
 	pos $t->{line} = $t->{line_cursor};
-	die "regex should always match" if $t->{line} !~ m/\G(.*?(?:\)|$))/gc;
+	die "regex should always match" if $t->{line} !~ m/\G(.*?\n?(?:\)|$))/gc;
 	$t->{token}->{content} .= $1;
 	$t->{line_cursor} += length $1;
 

--- a/t/signatures.t
+++ b/t/signatures.t
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+# PPI doesn't know about signatures, but we just want to ensure that it doesn't
+# lose newlines when it tracks the content of the token.
+
+use strict;
+use warnings;
+
+use PPI::Document ();
+use Test::More;
+
+my $sigs = <<'EOF';
+use strict;
+use warnings;
+
+use feature qw(signatures);
+no warnings qw(experimental::signatures);
+
+sub foo (
+    $self, $bar,
+    $thing_id = 12
+) {
+    1;
+}
+
+sub bar ($self,$bar,%) {
+    2;
+}
+
+sub baz (
+
+
+    $, $bar,
+
+    $thing_id = 12,
+
+    @
+
+
+) {
+    1;
+}
+
+sub other ( $= ) { }
+
+sub default ( $default = foo() ) { }
+
+EOF
+
+my $doc = PPI::Document->new( \$sigs );
+$doc->serialize;
+TODO: {
+    local $TODO = 'whitespace is not always preserved in signature';
+    is( $doc->content, $sigs, 'whitespace in signatures is preserved' );
+}
+
+done_testing();

--- a/t/signatures.t
+++ b/t/signatures.t
@@ -49,9 +49,6 @@ EOF
 
 my $doc = PPI::Document->new( \$sigs );
 $doc->serialize;
-TODO: {
-    local $TODO = 'whitespace is not always preserved in signature';
-    is( $doc->content, $sigs, 'whitespace in signatures is preserved' );
-}
+is( $doc->content, $sigs, 'whitespace in signatures is preserved' );
 
 done_testing();


### PR DESCRIPTION
I realize that PPI does not know about signatures, but when it treats them as prototypes it also removes any newlines inside the signature. So, something like:

```perl
sub foo (
    $self, $bar,
    $thing_id = 12
) {
    1;
}
```

gets turned into

```perl
sub foo (    $self, $bar,    $thing_id = 12) {
    1;
}
```

I have no idea about the correctness of this change, but it doesn't appear to break any existing tests, so there's that. ;) 