### PR TITLE
Return correct name for lexical subroutines

### DIFF
--- a/lib/PPI/Statement/Sub.pm
+++ b/lib/PPI/Statement/Sub.pm
@@ -75,7 +75,8 @@ sub name {
 	my ($self) = @_;
 
 	# Usually the second token is the name.
-	my $token = $self->schild(1);
+	# The third token is the name if this is a lexical subroutine.
+	my $token = $self->schild(defined $self->type ? 2 : 1);
 	return $token->content
 	  if defined $token and $token->isa('PPI::Token::Word');
 

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -4,7 +4,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 1240 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 1245 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 use PPI::Singletons '%KEYWORDS';
@@ -62,6 +62,7 @@ LEXSUB: {
 		isa_ok( $sub_statement, 'PPI::Statement::Sub', "$code: document child is a sub" );
 		is( $dummy, undef, "$code: document has exactly one child" );
 		is( $sub_statement->type, $type, "$code: type matches" );
+		is( $sub_statement->name, 'foo', "$code: name matches" );
 	}
 }
 


### PR DESCRIPTION
This pull request makes `PPI::Statement::Sub#name` method return correct name for lexical subroutines.

Fixes #260