### PR TITLE
Remove OurPkgVersion from dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -30,10 +30,6 @@ Test::More = 0.96
 -body = requires('File::Spec', is_os('MSWin32') ? '3.2701' : '0.84');
 -body = requires('IO::String') if $] < '5.008000';
 
-[OurPkgVersion]
-:version = 0.12
-underscore_eval_version = 1
-
 [Git::GatherDir]
 exclude_filename = README.pod
 [MetaYAML]


### PR DESCRIPTION
This has been obviated by our use of `@Git::VersionManager`
