### PR TITLE
Tidy imports in tests

### DIFF
--- a/t/03_document.t
+++ b/t/03_document.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 13 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI;
+use File::Spec::Functions qw( catfile );
+use PPI ();
 
 
 #####################################################################

--- a/t/04_element.t
+++ b/t/04_element.t
@@ -9,11 +9,10 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 220 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI;
-use Scalar::Util 'refaddr';
-use PPI::Test 'pause';
-use PPI::Singletons '%_PARENT';
+use PPI ();
+use PPI::Singletons qw( %_PARENT );
+use PPI::Test qw( pause );
+use Scalar::Util qw( refaddr );
 
 my $RE_IDENTIFIER = qr/[^\W\d]\w*/;
 
@@ -47,7 +46,7 @@ sub omethod_fails {
 
 # Confirm that C< weaken( $hash{scalar} = $object ) > works as expected,
 # adding a weak reference to the has index.
-use Scalar::Util ();
+use Scalar::Util qw( refaddr );
 SCOPE: {
 	my %hash;
 	my $counter = 0;

--- a/t/05_lexer.t
+++ b/t/05_lexer.t
@@ -7,9 +7,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 236 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI::Lexer;
-use PPI::Test::Run;
+use File::Spec::Functions qw( catdir );
+use PPI::Test::Run ();
 
 #####################################################################
 # Code/Dump Testing

--- a/t/06_round_trip.t
+++ b/t/06_round_trip.t
@@ -7,9 +7,9 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More; # Plan comes later
 
-use File::Spec::Functions ':ALL';
-use PPI;
-use PPI::Test 'find_files';
+use File::Spec::Functions qw( catdir );
+use PPI ();
+use PPI::Test qw( find_files );
 
 
 

--- a/t/07_token.t
+++ b/t/07_token.t
@@ -10,9 +10,9 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 588 + (warns_on_misplaced_underscore() ? 2 : 0 ) + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI;
-use PPI::Test::Run;
+use File::Spec::Functions qw( catdir );
+use PPI ();
+use PPI::Test::Run ();
 
 
 

--- a/t/08_regression.t
+++ b/t/08_regression.t
@@ -9,10 +9,10 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 1015 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use PPI::Test 'pause';
-use PPI::Test::Run;
-use PPI::Singletons '%_PARENT';
+use PPI ();
+use PPI::Test qw( pause );
+use PPI::Test::Run ();
+use PPI::Singletons qw( %_PARENT );
 
 
 

--- a/t/09_normal.t
+++ b/t/09_normal.t
@@ -7,9 +7,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 17 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI;
-use PPI::Singletons           '%LAYER';
+use PPI ();
+use PPI::Singletons qw( %LAYER );
 
 
 

--- a/t/10_statement.t
+++ b/t/10_statement.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 

--- a/t/11_util.t
+++ b/t/11_util.t
@@ -6,9 +6,9 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 10 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI;
-use PPI::Util qw{_Document _slurp};
+use File::Spec::Functions qw( catfile );
+use PPI ();
+use PPI::Util qw( _Document _slurp );
 
 # Execute the tests
 my $testfile   = catfile( 't', 'data', '11_util', 'test.pm' );

--- a/t/12_location.t
+++ b/t/12_location.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 682 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 my $test_source = <<'END_PERL';

--- a/t/13_data.t
+++ b/t/13_data.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 7 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI;
+use File::Spec::Functions qw( catfile );
+use PPI ();
 
 
 my $module = catfile('t', 'data', '13_data', 'Foo.pm');

--- a/t/14_charsets.t
+++ b/t/14_charsets.t
@@ -12,8 +12,8 @@ BEGIN {
 }
 
 use utf8;  # perl version check above says this is okay
-use Params::Util qw{_INSTANCE};
-use PPI;
+use Params::Util qw( _INSTANCE );
+use PPI ();
 
 sub good_ok {
 	my $source  = shift;
@@ -70,7 +70,7 @@ END_CODE
 
 	ok(utf8::is_utf8('κλειδί'), "utf8 flag set on source string");
 	good_ok( 'my %h = ( κλειδί => "Clé" );', "Hash with greek key in character string"          );
-	use Encode;
+	use Encode ();
 	my $bytes = Encode::encode('utf8', 'use utf8; my %h = ( κλειδί => "Clé" );');
 	ok(!utf8::is_utf8($bytes), "utf8 flag not set on byte string");
 

--- a/t/15_transform.t
+++ b/t/15_transform.t
@@ -2,13 +2,14 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
+
+use File::Copy qw( copy );
+use File::Spec::Functions qw( catdir catfile );
+use File::Temp qw( tempdir );
+use PPI ();
+use PPI::Transform ();
+use Scalar::Util qw( refaddr );
 use Test::More 0.86 tests => 24 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
-use File::Spec::Functions ':ALL';
-use File::Temp 'tempdir';
-use PPI;
-use PPI::Transform;
-use Scalar::Util 'refaddr';
-use File::Copy;
 
 #####################################################################
 # Begin Tests
@@ -105,7 +106,7 @@ like $@, qr/PPI::Transform does not implement the required ->document method/,
 # Test Transform class
 package MyCleaner;
 
-use Params::Util   qw{_INSTANCE};
+use Params::Util qw( _INSTANCE );
 use PPI::Transform ();
 
 our @ISA;

--- a/t/16_xml.t
+++ b/t/16_xml.t
@@ -2,9 +2,9 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
+use PPI::Document ();
 use Test::More 0.86 tests => 16 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
 
 
 
@@ -14,7 +14,7 @@ use PPI;
 # Begin Tests
 
 my $code = 'print "Hello World";';
-my $document = new_ok( 'PPI::Document' => [ \$code ] );
+my $document = new_ok( PPI::Document:: => [ \$code ] );
 
 my @elements = $document->elements;
 push @elements, $elements[0]->elements;

--- a/t/17_storable.t
+++ b/t/17_storable.t
@@ -4,7 +4,11 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
+
+use PPI ();
+use Scalar::Util qw( refaddr );
 use Test::More;
+
 BEGIN {
 	# Is Storable installed?
 	if ( eval { require Storable; 1 } ) {
@@ -15,8 +19,6 @@ BEGIN {
 	}
 }
 
-use Scalar::Util  'refaddr';
-use PPI;
 
 
 

--- a/t/18_cache.t
+++ b/t/18_cache.t
@@ -6,10 +6,9 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 40 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Unix;
-use File::Spec::Functions ':ALL';
-use File::Temp 'tempdir';
-use Scalar::Util        'refaddr';
+use File::Spec::Functions qw( catfile );
+use File::Temp qw( tempdir );
+use Scalar::Util qw( refaddr );
 use PPI::Document       ();
 use PPI::Cache          ();
 use Test::SubCalls 1.07 ();

--- a/t/19_selftesting.t
+++ b/t/19_selftesting.t
@@ -7,17 +7,17 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
+
+use Class::Inspector 1.22 ();
+use File::Spec::Functions qw( catdir );
+use Params::Util qw( _CLASS _ARRAY _INSTANCE _IDENTIFIER );
+use PPI ();
+use PPI::Test qw( find_files );
+use PPI::Test::Object (); ## no perlimports
 use Test::More; # Plan comes later
+use Test::Object qw( object_ok );
 
-use Test::Object;
-use File::Spec::Functions ':ALL';
-use Params::Util qw{_CLASS _ARRAY _INSTANCE _IDENTIFIER};
-use Class::Inspector 1.22;
-use PPI;
-use PPI::Test 'find_files';
-use PPI::Test::Object;
-
-use constant CI => 'Class::Inspector';
+use constant CI => Class::Inspector::;
 
 
 

--- a/t/21_exhaustive.t
+++ b/t/21_exhaustive.t
@@ -6,9 +6,9 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More; # Plan comes later
 
-use Params::Util qw{_INSTANCE};
-use PPI;
-use PPI::Test 'quotable';
+use Params::Util qw( _INSTANCE );
+use PPI ();
+use PPI::Test qw( quotable );
 
 # When distributing, keep this in to verify the test script
 # is working correctly, but limit to 2 (maaaaybe 3) so we

--- a/t/22_readonly.t
+++ b/t/22_readonly.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI::Document;
+use PPI::Document ();
 
 
 

--- a/t/23_file.t
+++ b/t/23_file.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 4 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI::Document::File;
+use File::Spec::Functions qw( catfile );
+use PPI::Document::File ();
 
 
 

--- a/t/24_v6.t
+++ b/t/24_v6.t
@@ -7,8 +7,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use File::Spec::Functions ':ALL';
-use PPI;
+use File::Spec::Functions qw( catfile );
+use PPI ();
 
 foreach my $file ( qw{
 	Simple.pm

--- a/t/25_increment.t
+++ b/t/25_increment.t
@@ -9,8 +9,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 8998 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use PPI::Test::Run;
+use PPI::Test::Run ();
 
 
 

--- a/t/26_bom.t
+++ b/t/26_bom.t
@@ -4,7 +4,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 20 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI::Test::Run;
+use PPI::Test::Run ();
 
 
 

--- a/t/27_complete.t
+++ b/t/27_complete.t
@@ -6,9 +6,9 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More; # Plan comes later
 
-use File::Spec::Functions ':ALL';
-use PPI;
-use PPI::Test 'find_files';
+use File::Spec::Functions qw( catdir );
+use PPI ();
+use PPI::Test qw( find_files );
 
 # This test uses a series of ordered files, containing test code.
 # The letter after the number acts as a boolean yes/no answer to

--- a/t/28_foreach_qw.t
+++ b/t/28_foreach_qw.t
@@ -7,7 +7,7 @@ use PPI::Test::pragmas;
 use Test::More tests => 12 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 #use File::Spec::Functions ':ALL';
-use PPI;
+use PPI ();
 
 
 

--- a/t/29_logical_filename.t
+++ b/t/29_logical_filename.t
@@ -10,15 +10,14 @@ BEGIN {
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
 
-use Test::More tests => 21;
-use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
-use PPI::Document;
-use PPI::Document::File;
+use File::Spec::Functions qw( catfile );
+use PPI::Document ();
+use PPI::Document::File ();
 use PPI::Util ();
+use Test::More tests => 20 + 1; # Test::NoWarnings
+use Test::NoWarnings; ## no perlimports
 
-
-for my $class ( qw{ PPI::Document PPI::Document::File } ) {
+for my $class ( ( PPI::Document::, PPI::Document::File:: ) ) {
 
 	#####################################################################
 	# Actual filename is used until #line directive

--- a/t/interactive.t
+++ b/t/interactive.t
@@ -8,7 +8,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 2 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 # Define the test code

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -3,6 +3,7 @@ package Helper;
 use strict;
 use warnings;
 use Exporter ();
+use PPI::Document ();
 
 our @ISA = "Exporter";
 our @EXPORT_OK = qw( check_with );

--- a/t/marpa.t
+++ b/t/marpa.t
@@ -5,9 +5,9 @@
 use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 23 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
-use B 'perlstring';
+use B qw( perlstring );
 
-use PPI;
+use PPI ();
 
 test_statement(
     'use v5 ;',

--- a/t/ppi_element.t
+++ b/t/ppi_element.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 57 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 __INSERT_AFTER: {

--- a/t/ppi_lexer.t
+++ b/t/ppi_lexer.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 46 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 UNMATCHED_BRACE: {

--- a/t/ppi_node.t
+++ b/t/ppi_node.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 6 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 PRUNE: {

--- a/t/ppi_normal.t
+++ b/t/ppi_normal.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 27 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 NEW: {

--- a/t/ppi_statement.t
+++ b/t/ppi_statement.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 22 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 SPECIALIZED: {

--- a/t/ppi_statement_compound.t
+++ b/t/ppi_statement_compound.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 52 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 TYPE: {

--- a/t/ppi_statement_include.t
+++ b/t/ppi_statement_include.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 2065 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use PPI::Singletons '%KEYWORDS';
+use PPI ();
+use PPI::Singletons qw( %KEYWORDS );
 
 
 TYPE: {

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 2506 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use PPI::Singletons '%KEYWORDS';
+use PPI ();
+use PPI::Singletons qw( %KEYWORDS );
 
 
 HASH_CONSTRUCTORS_DONT_CONTAIN_PACKAGES_RT52259: {

--- a/t/ppi_statement_scheduled.t
+++ b/t/ppi_statement_scheduled.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 240 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 SUB_WORD_OPTIONAL: {

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 1245 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use PPI::Singletons '%KEYWORDS';
+use PPI ();
+use PPI::Singletons qw( %KEYWORDS );
 
 NAME: {
 	for my $test (

--- a/t/ppi_statement_variable.t
+++ b/t/ppi_statement_variable.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 17 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 VARIABLES: {

--- a/t/ppi_token.t
+++ b/t/ppi_token.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 MODIFICATION: {
 	my $one = PPI::Token->new( "" );

--- a/t/ppi_token__quoteengine_full.t
+++ b/t/ppi_token__quoteengine_full.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 93 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 NEW: {

--- a/t/ppi_token_attribute.t
+++ b/t/ppi_token_attribute.t
@@ -6,8 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 1788 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use Test::Deep;
+use PPI ();
 
 sub execute_test;
 sub permute_test;

--- a/t/ppi_token_dashedword.t
+++ b/t/ppi_token_dashedword.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 9 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 LITERAL: {

--- a/t/ppi_token_heredoc.t
+++ b/t/ppi_token_heredoc.t
@@ -6,8 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 29 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use Test::Deep;
+use PPI ();
 
 sub h;
 

--- a/t/ppi_token_magic.t
+++ b/t/ppi_token_magic.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 38 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 __TOKENIZER_ON_CHAR: {

--- a/t/ppi_token_number_version.t
+++ b/t/ppi_token_number_version.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 735 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use PPI::Singletons qw' %OPERATOR %QUOTELIKE %KEYWORDS ';
+use PPI ();
+use PPI::Singletons qw( %KEYWORDS %OPERATOR %QUOTELIKE );
 
 
 LITERAL: {

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 1179 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use PPI::Singletons qw' %OPERATOR %KEYWORDS ';
+use PPI ();
+use PPI::Singletons qw( %KEYWORDS %OPERATOR );
 
 FIND_ONE_OP: {
 	my $source = '$a = .987;';

--- a/t/ppi_token_pod.t
+++ b/t/ppi_token_pod.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 MERGE: {

--- a/t/ppi_token_prototype.t
+++ b/t/ppi_token_prototype.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 800 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 PARSING: {

--- a/t/ppi_token_quote.t
+++ b/t/ppi_token_quote.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 15 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 STRING: {

--- a/t/ppi_token_quote_double.t
+++ b/t/ppi_token_quote_double.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 19 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 INTERPOLATIONS: {

--- a/t/ppi_token_quote_interpolate.t
+++ b/t/ppi_token_quote_interpolate.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 STRING: {

--- a/t/ppi_token_quote_literal.t
+++ b/t/ppi_token_quote_literal.t
@@ -5,9 +5,9 @@
 use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 14 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
-use B 'perlstring';
+use B qw( perlstring );
 
-use PPI;
+use PPI ();
 
 
 STRING: {

--- a/t/ppi_token_quote_single.t
+++ b/t/ppi_token_quote_single.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 24 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 STRING: {

--- a/t/ppi_token_quotelike_regexp.t
+++ b/t/ppi_token_quotelike_regexp.t
@@ -1,17 +1,15 @@
 #!/usr/bin/perl
 
 use strict;
-use File::Spec::Functions ':ALL';
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use PPI;
 
 # Execute the tests
 use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use lib 't/lib';
-use Helper 'check_with';
+use Helper qw( check_with );
 
 run();
 

--- a/t/ppi_token_quotelike_words.t
+++ b/t/ppi_token_quotelike_words.t
@@ -5,9 +5,8 @@
 use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 1940 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
-use Test::Deep;
 
-use PPI;
+use PPI ();
 
 sub permute_test;
 sub assemble_and_run;

--- a/t/ppi_token_regexp.t
+++ b/t/ppi_token_regexp.t
@@ -1,17 +1,15 @@
 #!/usr/bin/perl
 
 use strict;
-use File::Spec::Functions ':ALL';
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use PPI;
 
 # Execute the tests
 use Test::More tests => 7 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use lib 't/lib';
-use Helper 'check_with';
+use Helper qw( check_with );
 
 run();
 

--- a/t/ppi_token_structure.t
+++ b/t/ppi_token_structure.t
@@ -1,17 +1,13 @@
 #!/usr/bin/perl
 
 use strict;
-use File::Spec::Functions ':ALL';
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use PPI;
+use Helper qw( check_with );
 
 # Execute the tests
 use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
-
-use lib 't/lib';
-use Helper 'check_with';
 
 run();
 

--- a/t/ppi_token_symbol.t
+++ b/t/ppi_token_symbol.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 191 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
+use PPI ();
 
 
 my $Token = PPI::Token::Symbol->new( '$foo' );

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -6,8 +6,8 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 use Test::More tests => 776 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use PPI;
-use B 'perlstring';
+use PPI ();
+use B qw( perlstring );
 our %known_bad_seps;
 
 OPERATOR_CAST: {

--- a/t/ppi_token_whitespace.t
+++ b/t/ppi_token_whitespace.t
@@ -4,16 +4,15 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
+use PPI::Token::Whitespace ();
 use Test::More tests => 6 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
 
-use PPI;
-
 TIDY: {
-	my $ws1 = PPI::Token::Whitespace->new( "   " );
+	my $ws1 = PPI::Token::Whitespace::->new( "   " );
 	is $ws1->length, "3";
 	ok $ws1->tidy;
 	is $ws1->length, "3";
-	my $ws2 = PPI::Token::Whitespace->new( "   \n" );
+	my $ws2 = PPI::Token::Whitespace::->new( "   \n" );
 	is $ws2->length, "4";
 	ok $ws2->tidy;
 	is $ws2->length, "0";

--- a/t/ppi_token_word.t
+++ b/t/ppi_token_word.t
@@ -4,13 +4,10 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
+use Helper qw( check_with );
+
+use PPI ();
 use Test::More tests => 1762 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
-
-use PPI;
-
-
-use lib 't/lib';
-use Helper 'check_with';
 
 LITERAL: {
 	my @pairs = (


### PR DESCRIPTION
This makes the sources of imports a bit easier to track. It also removes
Test::Deep as a dependency.
