### PR TITLE
RFC: proof-of-concept for feature-tracking and perl sub signatures (see #273)

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,7 @@ Revision history for Perl extension PPI
 	  - PPI::Document->new( feature_mods => ... )
 	  - PPI::Document->new( custom_feature_includes => ... )
 	  - PPI::Document->new( custom_feature_include_cb => ... )
+	  - $ENV{PPI_CUSTOM_FEATURE_INCLUDES}
 	- Added ability to parse features:
 	  - signatures, as PPI::Structure::Signature
 	  - try catch, as PPI::Statement::Compound

--- a/Changes
+++ b/Changes
@@ -1,6 +1,14 @@
 Revision history for Perl extension PPI
 
 {{$NEXT}}
+	Summary:
+	- Implement support for parsing features
+
+	Details:
+	- Framework for recognition of parsing feature activation via:
+	  - `use $PERL_VERSION` in code
+	  - `use feature` in code
+	  - PPI::Document->new( feature_mods => ... )
 
 1.279   2024-08-23 14:02:44Z
 	Summary:

--- a/Changes
+++ b/Changes
@@ -10,6 +10,8 @@ Revision history for Perl extension PPI
 	  - `use feature` in code
 	  - `use $Common::CPAN::Module` in code
 	  - PPI::Document->new( feature_mods => ... )
+	  - PPI::Document->new( custom_feature_includes => ... )
+	  - PPI::Document->new( custom_feature_include_cb => ... )
 	- Added ability to parse features:
 	  - signatures, as PPI::Structure::Signature
 	  - try catch, as PPI::Statement::Compound

--- a/Changes
+++ b/Changes
@@ -2,13 +2,15 @@ Revision history for Perl extension PPI
 
 {{$NEXT}}
 	Summary:
-	- Implement support for parsing features
+	- Implement support for signatures and other parsing features
 
 	Details:
 	- Framework for recognition of parsing feature activation via:
 	  - `use $PERL_VERSION` in code
 	  - `use feature` in code
 	  - PPI::Document->new( feature_mods => ... )
+	- Added ability to parse features:
+	  - signatures, as PPI::Structure::Signature
 
 1.279   2024-08-23 14:02:44Z
 	Summary:

--- a/Changes
+++ b/Changes
@@ -8,9 +8,11 @@ Revision history for Perl extension PPI
 	- Framework for recognition of parsing feature activation via:
 	  - `use $PERL_VERSION` in code
 	  - `use feature` in code
+	  - `use $Common::CPAN::Module` in code
 	  - PPI::Document->new( feature_mods => ... )
 	- Added ability to parse features:
 	  - signatures, as PPI::Structure::Signature
+	  - try catch, as PPI::Statement::Compound
 
 1.279   2024-08-23 14:02:44Z
 	Summary:

--- a/lib/PPI/Document.pm
+++ b/lib/PPI/Document.pm
@@ -145,6 +145,32 @@ Setting feature_mods with a hashref allows defining perl parsing features to be
 enabled for the whole document. (e.g. when the code is assumed to be run as a
 oneliner)
 
+=head3 custom_feature_includes
+
+  custom_feature_includes =>
+    { strEct => { signatures => "Syntax::Keyword::Try" } }
+
+Setting custom_feature_includes with a hashref allows defining include names
+which act like pragmas that enable parsing features within their scope.
+
+This is mostly useful when your work project has its own boilerplate module.
+
+=head3 custom_feature_include_cb
+
+  custom_feature_include_cb => sub {
+    my ($statement) = @_;
+    return $statement->module eq "strEct" ? { signatures => "perl" } : ();
+  },
+
+Setting custom_feature_include_cb with a code reference causes all inspections
+on includes to call that sub before doing any other inspections. The sub can
+decide to either return a hashref of features to be enabled or disabled, which
+will be used for the scope the include was called in, or undef to continue with
+the default inspections. The argument to the sub will be the
+L<PPI::Statement::Include> object.
+
+This can be useful when your work project has a complex boilerplate module.
+
 =cut
 
 sub new {
@@ -232,9 +258,11 @@ sub load {
 
 sub _setattr {
 	my ( $class, $document, %attr ) = @_;
-	$document->{readonly}     = !!$attr{readonly};
-	$document->{filename}     = $attr{filename};
-	$document->{feature_mods} = $attr{feature_mods};
+	$document->{readonly}                  = !!$attr{readonly};
+	$document->{filename}                  = $attr{filename};
+	$document->{feature_mods}              = $attr{feature_mods};
+	$document->{custom_feature_includes}   = $attr{custom_feature_includes};
+	$document->{custom_feature_include_cb} = $attr{custom_feature_include_cb};
 	return $document;
 }
 
@@ -358,6 +386,26 @@ sub feature_mods {
 	my $self = shift;
 	return $self->{feature_mods} unless @_;
 	$self->{feature_mods} = shift;
+}
+
+=head2 custom_feature_includes { module_name => { feature_name => $provider } }
+
+=cut
+
+sub custom_feature_includes {
+	my $self = shift;
+	return $self->{custom_feature_includes} unless @_;
+	$self->{custom_feature_includes} = shift;
+}
+
+=head2 custom_feature_include_cb sub { ... }
+
+=cut
+
+sub custom_feature_include_cb {
+	my $self = shift;
+	return $self->{custom_feature_include_cb} unless @_;
+	$self->{custom_feature_include_cb} = shift;
 }
 
 =pod

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -458,9 +458,32 @@ sub previous_token {
 	}
 }
 
+=head2 presumed_features
 
+Returns a hash that indicates which features appear to be active for the given
+element.
 
+=cut
 
+sub presumed_features {
+	my ($self) = @_;
+
+	my @feature_mods;
+	my $walker = $self;
+	while ($walker) {
+		my $sib_walk = $walker;
+		while ($sib_walk) {
+			push @feature_mods, $sib_walk if $sib_walk->can("feature_mods");
+			$sib_walk = $sib_walk->sprevious_sibling;
+		}
+		$walker = $walker->parent;
+	}
+
+	my %feature_mods = map %{$_}, reverse grep defined, map $_->feature_mods,
+	  @feature_mods;
+
+	return \%feature_mods;
+}
 
 #####################################################################
 # Manipulation

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -209,11 +209,13 @@ sub lex_tokenizer {
 
 	# Create the empty document
 	my $Document = PPI::Document->new;
+	$Tokenizer->_document($Document);
 
 	# Lex the token stream into the document
 	$self->{Tokenizer} = $Tokenizer;
 	if ( !eval { $self->_lex_document($Document); 1 } ) {
 		# If an error occurs DESTROY the partially built document.
+		$Tokenizer->_document(undef);
 		undef $Document;
 		if ( _INSTANCE($@, 'PPI::Exception') ) {
 			return $self->_error( $@->message );

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -1044,6 +1044,8 @@ sub _round {
 		return 'PPI::Structure::Given';
 	} elsif ( $Parent->isa('PPI::Statement::When') ) {
 		return 'PPI::Structure::When';
+	} elsif ( $Parent->isa('PPI::Statement::Sub') ) {
+		return 'PPI::Structure::Signature';
 	}
 
 	# Otherwise, it must be a list

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -133,6 +133,8 @@ creates a L<PPI::Tokenizer> for the content and lexes the token stream
 produced by the tokenizer. Basically, a sort of all-in-one method for
 getting a L<PPI::Document> object from a file name.
 
+Additional arguments are passed to the tokenizer as a hash.
+
 Returns a L<PPI::Document> object, or C<undef> on error.
 
 =cut
@@ -143,6 +145,7 @@ sub lex_file {
 	unless ( defined $file ) {
 		return $self->_error("Did not pass a filename to PPI::Lexer::lex_file");
 	}
+	my %args = @_;
 
 	# Create the Tokenizer
 	my $Tokenizer = eval {
@@ -154,7 +157,7 @@ sub lex_file {
 		return $self->_error( $errstr );
 	}
 
-	$self->lex_tokenizer( $Tokenizer );
+	$self->lex_tokenizer( $Tokenizer, %args );
 }
 
 =pod
@@ -164,6 +167,8 @@ sub lex_file {
 The C<lex_source> method takes a normal scalar string as argument. It
 creates a L<PPI::Tokenizer> object for the string, and then lexes the
 resulting token stream.
+
+Additional arguments are passed to the tokenizer as a hash.
 
 Returns a L<PPI::Document> object, or C<undef> on error.
 
@@ -175,6 +180,7 @@ sub lex_source {
 	unless ( defined $source and not ref $source ) {
 		return $self->_error("Did not pass a string to PPI::Lexer::lex_source");
 	}
+	my %args = @_;
 
 	# Create the Tokenizer and hand off to the next method
 	my $Tokenizer = eval {
@@ -186,7 +192,7 @@ sub lex_source {
 		return $self->_error( $errstr );
 	}
 
-	$self->lex_tokenizer( $Tokenizer );
+	$self->lex_tokenizer( $Tokenizer, %args );
 }
 
 =pod
@@ -195,6 +201,8 @@ sub lex_source {
 
 The C<lex_tokenizer> takes as argument a L<PPI::Tokenizer> object. It
 lexes the token stream from the tokenizer into a L<PPI::Document> object.
+
+Additional arguments are set on the L<PPI::Document> produced.
 
 Returns a L<PPI::Document> object, or C<undef> on error.
 
@@ -206,9 +214,11 @@ sub lex_tokenizer {
 	return $self->_error(
 		"Did not pass a PPI::Tokenizer object to PPI::Lexer::lex_tokenizer"
 	) unless $Tokenizer;
+	my %args = @_;
 
 	# Create the empty document
 	my $Document = PPI::Document->new;
+	ref($Document)->_setattr( $Document, %args ) if keys %args;
 	$Tokenizer->_document($Document);
 
 	# Lex the token stream into the document

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -218,7 +218,7 @@ sub lex_tokenizer {
 
 	# Create the empty document
 	my $Document = PPI::Document->new;
-	ref($Document)->_setattr( $Document, %args ) if keys %args;
+	ref($Document)->_setattr( $Document, %args );
 	$Tokenizer->_document($Document);
 
 	# Lex the token stream into the document

--- a/lib/PPI/Statement/Compound.pm
+++ b/lib/PPI/Statement/Compound.pm
@@ -128,7 +128,11 @@ sub type {
 		}
 		return 'for';
 	}
-	return $TYPES{$content} if $Element->isa('PPI::Token::Word');
+	return {
+		%TYPES,
+		( try => 'try' ) x !!$self->presumed_features->{try},
+	}->{$content}
+	  if $Element->isa('PPI::Token::Word');
 	return 'continue'       if $Element->isa('PPI::Structure::Block');
 
 	# Unknown (shouldn't exist?)

--- a/lib/PPI/Statement/Include.pm
+++ b/lib/PPI/Statement/Include.pm
@@ -270,7 +270,7 @@ sub feature_mods {
 		  if version::->parse($perl_version) >= 5.035;
 	}
 
-	my %known     = ( signatures => 1 );
+	my %known     = ( signatures => 1, try => 1 );
 	my $on_or_off = $self->type eq "use";
 
 	if ( $self->module eq "feature" ) {
@@ -284,6 +284,9 @@ sub feature_mods {
 	elsif ( $self->module eq "Modern::Perl" ) {
 		my $v = $self->module_version->$_call_if_object("literal") || 0;
 		return { signatures => $v >= 2023 ? "perl" : 0 };
+	}
+	elsif ( $self->module eq "Syntax::Keyword::Try" ) {
+		return { try => $on_or_off ? "Syntax::Keyword::Try" : 0 };
 	}
 
 	return;

--- a/lib/PPI/Statement/Include.pm
+++ b/lib/PPI/Statement/Include.pm
@@ -292,6 +292,10 @@ sub feature_mods {
 		my $v = $self->module_version->$_call_if_object("literal") || 0;
 		return { signatures => $v >= 2023 ? "perl" : 0 };
 	}
+	elsif ( $self->module eq "experimental" ) {
+		my $wants_signatures = grep /signatures/, $self->_decompose_arguments;
+		return { signatures => $wants_signatures ? "perl" : 0 };
+	}
 	elsif ( $self->module eq "Syntax::Keyword::Try" ) {
 		return { try => $on_or_off ? "Syntax::Keyword::Try" : 0 };
 	}

--- a/lib/PPI/Statement/Include.pm
+++ b/lib/PPI/Statement/Include.pm
@@ -260,6 +260,9 @@ sub feature_mods {
 	my ($self) = @_;
 	return if $self->type eq "require";
 
+	if ( my $cb_features = $self->_custom_feature_include_cb->($self) )    #
+	{ return $cb_features; }
+
 	if ( my $perl_version = $self->version ) {
 		## tried using feature.pm, but it is impossible to install future
 		## versions of it, so e.g. a 5.20 install cannot know about
@@ -272,6 +275,10 @@ sub feature_mods {
 
 	my %known     = ( signatures => 1, try => 1 );
 	my $on_or_off = $self->type eq "use";
+
+	if ( $on_or_off
+		and my $custom = $self->_custom_feature_includes->{ $self->module } )  #
+	{ return $custom; }
 
 	if ( $self->module eq "feature" ) {
 		my @features = grep $known{$_}, $self->_decompose_arguments;
@@ -309,6 +316,20 @@ sub _decompose_argument {
 	my $as_text = $arg->can("literal") || $arg->can("string");
 	return $as_text->($arg) if $as_text;
 	die "unknown arg decompose type: $arg , " . ref $arg;
+}
+
+sub _custom_feature_includes {
+	my ($self) = @_;
+	return unless                                                             #
+	  my $document = $self->document;
+	return $document->custom_feature_includes || {};
+}
+
+sub _custom_feature_include_cb {
+	my ($self) = @_;
+	return unless                                                             #
+	  my $document = $self->document;
+	return $document->custom_feature_include_cb || sub { };
 }
 
 1;

--- a/lib/PPI/Structure.pm
+++ b/lib/PPI/Structure.pm
@@ -108,6 +108,7 @@ use PPI::Structure::List        ();
 use PPI::Structure::Subscript   ();
 use PPI::Structure::Unknown     ();
 use PPI::Structure::When        ();
+use PPI::Structure::Signature   ();
 
 
 

--- a/lib/PPI/Structure/Signature.pm
+++ b/lib/PPI/Structure/Signature.pm
@@ -1,0 +1,61 @@
+package PPI::Structure::Signature;
+
+=pod
+
+=head1 NAME
+
+PPI::Structure::Signature - List of subroutine signature elements
+
+=head1 SYNOPSIS
+
+  sub do_thing( $param, $arg ) {}
+
+=head1 INHERITANCE
+
+  PPI::Structure::Signature
+    isa PPI::Structure::List
+        isa PPI::Structure
+            isa PPI::Node
+                isa PPI::Element
+
+=head1 DESCRIPTION
+
+C<PPI::Structure::Signature> is the class used for circular braces that
+represent lists of signature elements.
+
+=head1 METHODS
+
+C<PPI::Structure::Signature> has no methods beyond those provided by the
+standard L<PPI::Structure::List>, L<PPI::Structure>, L<PPI::Node> and
+L<PPI::Element> methods.
+
+=cut
+
+use strict;
+use PPI::Structure ();
+
+our $VERSION = '1.277';
+
+our @ISA = "PPI::Structure::List";
+
+1;
+
+=head1 SUPPORT
+
+See the L<support section|PPI/SUPPORT> in the main module.
+
+=head1 AUTHOR
+
+Adam Kennedy E<lt>adamk@cpan.orgE<gt>
+
+=head1 COPYRIGHT
+
+Copyright 2001 - 2011 Adam Kennedy.
+
+This program is free software; you can redistribute
+it and/or modify it under the same terms as Perl itself.
+
+The full text of the license can be found in the
+LICENSE file included with this module.
+
+=cut

--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -115,6 +115,15 @@ sub __TOKENIZER__on_char {
 			return 1;
 		}
 
+		# Is it a nameless arg in a signature?
+		if ( $char eq ')' or $char eq '=' or $char eq ',' ) {
+			my ($has_sig) = $t->_current_token_has_signatures_active;
+			if ($has_sig) {
+				$t->{class} = $t->{token}->set_class('Symbol');
+				return $t->_finalize_token->__TOKENIZER__on_char($t);
+			}
+		}
+
 		if ( $MAGIC{ $c . $char } ) {
 			# Magic variable
 			$t->{class} = $t->{token}->set_class( 'Magic' );
@@ -151,6 +160,15 @@ sub __TOKENIZER__on_char {
 			# Symbol
 			$t->{class} = $t->{token}->set_class( 'Symbol' );
 			return 1;
+		}
+
+		# Is it a nameless arg in a signature?
+		if ( $char eq ')' ) {
+			my ($has_sig) = $t->_current_token_has_signatures_active;
+			if ($has_sig) {
+				$t->{class} = $t->{token}->set_class('Symbol');
+				return $t->_finalize_token->__TOKENIZER__on_char($t);
+			}
 		}
 
 		if ( $MAGIC{ $c . $char } ) {
@@ -196,6 +214,15 @@ sub __TOKENIZER__on_char {
 			# bitwise operator
 			$t->{class} = $t->{token}->set_class( 'Operator' );
 			return $t->_finalize_token->__TOKENIZER__on_char( $t );
+		}
+
+		# Is it a nameless arg in a signature?
+		if ( $char eq ')' ) {
+			my ($has_sig) = $t->_current_token_has_signatures_active;
+			if ($has_sig) {
+				$t->{class} = $t->{token}->set_class('Symbol');
+				return $t->_finalize_token->__TOKENIZER__on_char($t);
+			}
 		}
 
 		# Is it a magic variable?

--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -212,8 +212,8 @@ sub __TOKENIZER__on_char {
 		# 2. The one before that is the word 'sub'.
 		# 3. The one before that is a 'structure'
 
-		# Get the three previous significant tokens
-		my @tokens = $t->_previous_significant_tokens(3);
+		my ( $has_sig, @tokens ) = $t->_current_token_has_signatures_active;
+		return 'Structure' if $has_sig;
 
 		# A normal subroutine declaration
 		my $p1 = $tokens[1];

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -159,6 +159,7 @@ sub new {
 		# Source code
 		source       => undef,
 		source_bytes => undef,
+		document     => undef,
 
 		# Line buffer
 		line         => undef,
@@ -246,6 +247,11 @@ sub new {
 	}
 
 	$self;
+}
+
+sub _document {
+	my $self = shift;
+	return @_ ? $self->{document} = shift : $self->{document};
 }
 
 

--- a/t/feature_tracking.t
+++ b/t/feature_tracking.t
@@ -2,7 +2,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 12 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
+use Test::More tests => 13 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
 
 use B 'perlstring';
 
@@ -384,6 +384,33 @@ END_PERL
 		'PPI::Structure::Block',      '{}',
 		'PPI::Token::Structure',      '{',
 		'PPI::Token::Structure',      '}',
+	  ],
+	  "simple custom boilerplate modules";
+}
+
+CPAN_EXPERIMENTAL: {
+	test_document
+	  <<'END_PERL',
+		use experimental qw( signatures );
+		sub meep($) {}
+END_PERL
+	  [
+		'PPI::Statement::Include',      'use experimental qw( signatures );',
+		'PPI::Token::Word',             'use',
+		'PPI::Token::Word',             'experimental',
+		'PPI::Token::QuoteLike::Words', 'qw( signatures )',
+		'PPI::Token::Structure',        ';',
+		'PPI::Statement::Sub',          'sub meep($) {}',
+		'PPI::Token::Word',             'sub',
+		'PPI::Token::Word',             'meep',
+		'PPI::Structure::Signature',    '($)',
+		'PPI::Token::Structure',        '(',
+		'PPI::Statement::Expression',   '$',
+		'PPI::Token::Symbol',           '$',
+		'PPI::Token::Structure',        ')',
+		'PPI::Structure::Block',        '{}',
+		'PPI::Token::Structure',        '{',
+		'PPI::Token::Structure',        '}',
 	  ],
 	  "simple custom boilerplate modules";
 }

--- a/t/feature_tracking.t
+++ b/t/feature_tracking.t
@@ -2,7 +2,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 9 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
+use Test::More tests => 11 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
 
 use B 'perlstring';
 
@@ -200,6 +200,97 @@ END_PERL
 		'PPI::Token::Structure',      '}',
 	  ],
 	  "core try";
+}
+
+HOMEBREW_ARGS: {
+	test_document
+	  [ custom_feature_includes => { strEct => { signatures => 1 } } ],
+	  <<'END_PERL',
+		use strEct;
+		sub meep($) {}
+		sub marp($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Include',    'use strEct;',
+		'PPI::Token::Word',           'use',
+		'PPI::Token::Word',           'strEct',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Structure::Signature',  '($)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+		'PPI::Statement::Sub',        'sub marp($left, $right) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'marp',
+		'PPI::Structure::Signature',  '($left, $right)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "simple custom boilerplate modules";
+}
+
+HOMEBREW_CB: {
+	test_document    #
+	  [
+		custom_feature_include_cb => sub {
+			my ($inc) = @_;
+			my ($arg) = $inc->arguments;
+			return ( $inc->module eq "strEct" and $arg->string eq "sigg" )
+			  ? { signatures => 1 }
+			  : ();
+		}
+	  ],
+	  <<'END_PERL',
+		use strEct "sigg";
+		sub meep($) {}
+		sub marp($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Include',    'use strEct "sigg";',
+		'PPI::Token::Word',           'use',
+		'PPI::Token::Word',           'strEct',
+		'PPI::Token::Quote::Double',  '"sigg"',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Structure::Signature',  '($)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+		'PPI::Statement::Sub',        'sub marp($left, $right) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'marp',
+		'PPI::Structure::Signature',  '($left, $right)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "callback for complex custom boilerplate modules";
 }
 
 CPAN_MOJOLICIOUS_LITE: {

--- a/t/feature_tracking.t
+++ b/t/feature_tracking.t
@@ -2,7 +2,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 6 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
+use Test::More tests => 9 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
 
 use B 'perlstring';
 
@@ -128,6 +128,78 @@ END_PERL
 		'PPI::Token::Structure',      '}',
 	  ],
 	  "disabling of features";
+}
+
+PROTOTYPE_ATTR: {
+	test_document
+	  <<'END_PERL',
+		sub meep :prototype($) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub'   => 'sub meep :prototype($) {}',
+		'PPI::Token::Word'      => 'sub',
+		'PPI::Token::Word'      => 'meep',
+		'PPI::Token::Operator'  => ':',
+		'PPI::Token::Attribute' => 'prototype($)',
+		'PPI::Structure::Block' => '{}',
+		'PPI::Token::Structure' => '{',
+		'PPI::Token::Structure' => '}',
+	  ],
+	  "prototype attribute";
+}
+
+SYNTAX_KEYWORD_TRY: {
+	test_document
+	  <<'END_PERL',
+		use Syntax::Keyword::Try;
+		try{}catch{}
+END_PERL
+	  [
+		'PPI::Statement::Include'  => 'use Syntax::Keyword::Try;',
+		'PPI::Token::Word'         => 'use',
+		'PPI::Token::Word'         => 'Syntax::Keyword::Try',
+		'PPI::Token::Structure'    => ';',
+		'PPI::Statement::Compound' => 'try{}catch{}',
+		'PPI::Token::Word'         => 'try',
+		'PPI::Structure::Block'    => '{}',
+		'PPI::Token::Structure'    => '{',
+		'PPI::Token::Structure'    => '}',
+		'PPI::Token::Word'         => 'catch',
+		'PPI::Structure::Block'    => '{}',
+		'PPI::Token::Structure'    => '{',
+		'PPI::Token::Structure'    => '}',
+	  ],
+	  "Syntax::Keyword::Try";
+}
+
+CORE_TRY: {
+	test_document
+	  <<'END_PERL',
+		use feature "try";
+		try{}catch($e){}
+END_PERL
+	  [
+		'PPI::Statement::Include',    'use feature "try";',
+		'PPI::Token::Word',           'use',
+		'PPI::Token::Word',           'feature',
+		'PPI::Token::Quote::Double',  '"try"',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Compound',   'try{}catch($e){}',
+		'PPI::Token::Word',           'try',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+		'PPI::Token::Word',           'catch',
+		'PPI::Structure::List',       '($e)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$e',
+		'PPI::Token::Symbol',         '$e',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "core try";
 }
 
 CPAN_MOJOLICIOUS_LITE: {

--- a/t/feature_tracking.t
+++ b/t/feature_tracking.t
@@ -2,7 +2,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 11 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
+use Test::More tests => 12 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
 
 use B 'perlstring';
 
@@ -205,6 +205,47 @@ END_PERL
 HOMEBREW_ARGS: {
 	test_document
 	  [ custom_feature_includes => { strEct => { signatures => 1 } } ],
+	  <<'END_PERL',
+		use strEct;
+		sub meep($) {}
+		sub marp($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Include',    'use strEct;',
+		'PPI::Token::Word',           'use',
+		'PPI::Token::Word',           'strEct',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Structure::Signature',  '($)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+		'PPI::Statement::Sub',        'sub marp($left, $right) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'marp',
+		'PPI::Structure::Signature',  '($left, $right)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "simple custom boilerplate modules";
+}
+
+ENV_HOMEBREW_ARGS: {
+	local $ENV{PPI_CUSTOM_FEATURE_INCLUDES} = "strEct: {signatures: perl}";
+	test_document
 	  <<'END_PERL',
 		use strEct;
 		sub meep($) {}

--- a/t/feature_tracking.t
+++ b/t/feature_tracking.t
@@ -1,0 +1,228 @@
+#!/usr/bin/perl
+
+use lib 't/lib';
+use PPI::Test::pragmas;
+use Test::More tests => 6 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
+
+use B 'perlstring';
+
+use PPI ();
+use PPI::Dumper;
+
+#use DB::Skip subs => [
+#	qw( PPI::Document::new  PPI::Lexer::lex_source  PPI::Lexer::new
+#	  PPI::Lexer::_clear  PPI::Lexer::(eval)  PPI::Lexer::X_TOKENIZER
+#	  PPI::Tokenizer::new  PPI::Lexer::lex_tokenizer  PPI::Node::new  ),
+#	qr/^PPI::Tokenizer::__ANON__.*237.*$/
+#];
+
+sub test_document;
+
+FEATURE_TRACKING: {
+	test_document
+	  <<'END_PERL',
+		sub meep($) {}
+		use 5.035;
+		sub marp($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Token::Prototype',      '($)',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+		'PPI::Statement::Include',    'use 5.035;',
+		'PPI::Token::Word',           'use',
+		'PPI::Token::Number::Float',  '5.035',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Sub',        'sub marp($left, $right) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'marp',
+		'PPI::Structure::Signature',  '($left, $right)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}'
+	  ],
+	  "enabling of features";
+}
+
+DOCUMENT_FEATURES: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub meep($) {}
+		sub marp($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Structure::Signature',  '($)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+		'PPI::Statement::Sub',        'sub marp($left, $right) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'marp',
+		'PPI::Structure::Signature',  '($left, $right)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "document-level default features";
+}
+
+DISABLE_FEATURE: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub meep($) {}
+		no feature ('signatures');
+		sub marp($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Structure::Signature',  '($)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+		'PPI::Statement::Include',    'no feature (\'signatures\');',
+		'PPI::Token::Word',           'no',
+		'PPI::Token::Word',           'feature',
+		'PPI::Structure::List',       '(\'signatures\')',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '\'signatures\'',
+		'PPI::Token::Quote::Single',  '\'signatures\'',
+		'PPI::Token::Structure',      ')',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Sub',        'sub marp($left, $right) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'marp',
+		'PPI::Token::Prototype',      '($left, $right)',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "disabling of features";
+}
+
+CPAN_MOJOLICIOUS_LITE: {
+	test_document
+	  <<'END_PERL',
+		use Mojolicious::Lite -signatures;
+		sub meep($) {}
+END_PERL
+	  [
+		'PPI::Statement::Include',    'use Mojolicious::Lite -signatures;',
+		'PPI::Token::Word',           'use',
+		'PPI::Token::Word',           'Mojolicious::Lite',
+		'PPI::Token::Word',           '-signatures',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Structure::Signature',  '($)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "simple custom boilerplate modules";
+}
+
+CPAN_MODERN_PERL: {
+	test_document
+	  <<'END_PERL',
+		use Modern::Perl 2023;
+		sub meep($) {}
+END_PERL
+	  [
+		'PPI::Statement::Include',    'use Modern::Perl 2023;',
+		'PPI::Token::Word',           'use',
+		'PPI::Token::Word',           'Modern::Perl',
+		'PPI::Token::Number',         '2023',
+		'PPI::Token::Structure',      ';',
+		'PPI::Statement::Sub',        'sub meep($) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'meep',
+		'PPI::Structure::Signature',  '($)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "simple custom boilerplate modules";
+}
+
+
+ok( PPI::Tokenizer->new( \"d()" )->all_tokens, "bare tokenizer auto-vivifies document object" );
+
+### TODO from ppi_token_unknown.t , deduplicate
+
+sub one_line_explain {
+	my ($data) = @_;
+	my @explain = explain $data;
+	s/\n//g for @explain;
+	return join "", @explain;
+}
+
+sub main_level_line {
+	return "" if not $TODO;
+	my @outer_final;
+	my $level = 0;
+	while ( my @outer = caller( $level++ ) ) {
+		@outer_final = @outer;
+	}
+	return "l $outer_final[2] - ";
+}
+
+sub test_document {
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+	my $args = ref $_[0] eq "ARRAY" ? shift : [];
+	my ( $code, $expected, $msg ) = @_;
+	$msg = perlstring $code if !defined $msg;
+
+	my $d      = PPI::Document->new( \$code, @{$args} ) or die explain $@;
+	my $tokens = $d->find( sub { $_[1]->significant } );
+	$tokens = [ map { ref($_), $_->content } @$tokens ];
+
+	my $ok = is_deeply( $tokens, $expected, main_level_line . $msg );
+	if ( !$ok ) {
+		diag ">>> $code -- $msg\n";
+		diag( PPI::Dumper->new($d)->string );
+		diag one_line_explain $tokens;
+		diag one_line_explain $expected;
+	}
+
+	return;
+}

--- a/t/signature_details.t
+++ b/t/signature_details.t
@@ -1,0 +1,459 @@
+#!/usr/bin/perl
+
+use lib 't/lib';
+use PPI::Test::pragmas;
+use Test::More tests => 16 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
+
+use B 'perlstring';
+
+use PPI ();
+use PPI::Dumper;
+
+sub test_document;
+
+BASE_SIGNATURE_EXAMPLE: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($left, $right) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($left, $right)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "base signature example";
+}
+
+UNNAMED_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($first, $, $third) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($first, $, $third) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($first, $, $third)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$first, $, $third',
+		'PPI::Token::Symbol',         '$first',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$third',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "unnamed argument";
+}
+
+POSITIONAL_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($left, $right = 0) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($left, $right = 0) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($left, $right = 0)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right = 0',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Operator',       '=',
+		'PPI::Token::Number',         '0',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "positional argument";
+}
+
+INCREMENT_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($thing, $id = $auto_id++) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($thing, $id = $auto_id++) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($thing, $id = $auto_id++)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$thing, $id = $auto_id++',
+		'PPI::Token::Symbol',         '$thing',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$id',
+		'PPI::Token::Operator',       '=',
+		'PPI::Token::Symbol',         '$auto_id',
+		'PPI::Token::Operator',       '++',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "increment argument";
+}
+
+DEFAULT_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($first_name, $surname, $nickname = $first_name) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub' =>
+		  'sub foo ($first_name, $surname, $nickname = $first_name) {}',    #
+		'PPI::Token::Word', 'sub',
+		'PPI::Token::Word', 'foo',
+		'PPI::Structure::Signature' =>
+		  '($first_name, $surname, $nickname = $first_name)',
+		'PPI::Token::Structure', '(',
+		'PPI::Statement::Expression' =>
+		  '$first_name, $surname, $nickname = $first_name',
+		'PPI::Token::Symbol',    '$first_name',
+		'PPI::Token::Operator',  ',',
+		'PPI::Token::Symbol',    '$surname',
+		'PPI::Token::Operator',  ',',
+		'PPI::Token::Symbol',    '$nickname',
+		'PPI::Token::Operator',  '=',
+		'PPI::Token::Symbol',    '$first_name',
+		'PPI::Token::Structure', ')',
+		'PPI::Structure::Block', '{}',
+		'PPI::Token::Structure', '{',
+		'PPI::Token::Structure', '}',
+	  ],
+	  "default argument";
+}
+
+UNDEF_DEFAULT_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($name //= "world") {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($name //= "world") {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($name //= "world")',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$name //= "world"',
+		'PPI::Token::Symbol',         '$name',
+		'PPI::Token::Operator',       '//=',
+		'PPI::Token::Quote::Double',  '"world"',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "undef default argument";
+}
+
+OR_DEFAULT_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($name ||= "world") {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($name ||= "world") {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($name ||= "world")',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$name ||= "world"',
+		'PPI::Token::Symbol',         '$name',
+		'PPI::Token::Operator',       '||=',
+		'PPI::Token::Quote::Double',  '"world"',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "or default argument";
+}
+
+NAMELESS_OPTIONAL_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($thing, $ = 1) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($thing, $ = 1) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($thing, $ = 1)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$thing, $ = 1',
+		'PPI::Token::Symbol',         '$thing',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Cast',           '$',
+		'PPI::Token::Operator',       '=',
+		'PPI::Token::Number',         '1',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "nameless optional argument";
+}
+
+VALUELESS_OPTIONAL_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($thing, $=) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($thing, $=) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($thing, $=)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$thing, $=',
+		'PPI::Token::Symbol',         '$thing',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$',
+		'PPI::Token::Operator',       '=',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "valueless optional argument";
+}
+
+SLURPY_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($filter, @inputs) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($filter, @inputs) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($filter, @inputs)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$filter, @inputs',
+		'PPI::Token::Symbol',         '$filter',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '@inputs',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "slurpy argument";
+}
+
+NAMELESS_SLURPY_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($thing, @) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($thing, @) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($thing, @)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$thing, @',
+		'PPI::Token::Symbol',         '$thing',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '@',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "nameless slurpy argument";
+}
+
+SLURPY_HASH_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($filter, %inputs) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($filter, %inputs) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($filter, %inputs)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$filter, %inputs',
+		'PPI::Token::Symbol',         '$filter',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '%inputs',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "slurpy hash argument";
+}
+
+NAMELESS_SLURPY_HASH_ARGUMENT: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo ($thing, %) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',        'sub foo ($thing, %) {}',
+		'PPI::Token::Word',           'sub',
+		'PPI::Token::Word',           'foo',
+		'PPI::Structure::Signature',  '($thing, %)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$thing, %',
+		'PPI::Token::Symbol',         '$thing',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '%',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "nameless slurpy hash argument";
+}
+
+EMPTY_SIGNATURE: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo () {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',       'sub foo () {}',
+		'PPI::Token::Word',          'sub',
+		'PPI::Token::Word',          'foo',
+		'PPI::Structure::Signature', '()',
+		'PPI::Token::Structure',     '(',
+		'PPI::Token::Structure',     ')',
+		'PPI::Structure::Block',     '{}',
+		'PPI::Token::Structure',     '{',
+		'PPI::Token::Structure',     '}',
+	  ],
+	  "empty signature";
+}
+
+PROTOTYPE_SIGNATURE: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo :prototype($$) ($left, $right) {}
+END_PERL
+	  [
+		'PPI::Statement::Sub',   'sub foo :prototype($$) ($left, $right) {}',  #
+		'PPI::Token::Word',      'sub',
+		'PPI::Token::Word',      'foo',
+		'PPI::Token::Operator',  ':',
+		'PPI::Token::Attribute', 'prototype($$)',
+		'PPI::Structure::Signature',  '($left, $right)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$left, $right',
+		'PPI::Token::Symbol',         '$left',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$right',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{}',
+		'PPI::Token::Structure',      '{',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "prototype signature";
+}
+
+COMPLEX_SIGNATURE_EXAMPLE: {
+	test_document
+	  [ feature_mods => { signatures => 1 } ],
+	  <<'END_PERL',
+		sub foo :lvalue ($x, $y = 1, @z) { ... }
+END_PERL
+	  [
+		'PPI::Statement::Sub',   'sub foo :lvalue ($x, $y = 1, @z) { ... }',   #
+		'PPI::Token::Word',      'sub',
+		'PPI::Token::Word',      'foo',
+		'PPI::Token::Operator',  ':',
+		'PPI::Token::Attribute', 'lvalue',
+		'PPI::Structure::Signature',  '($x, $y = 1, @z)',
+		'PPI::Token::Structure',      '(',
+		'PPI::Statement::Expression', '$x, $y = 1, @z',
+		'PPI::Token::Symbol',         '$x',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '$y',
+		'PPI::Token::Operator',       '=',
+		'PPI::Token::Number',         '1',
+		'PPI::Token::Operator',       ',',
+		'PPI::Token::Symbol',         '@z',
+		'PPI::Token::Structure',      ')',
+		'PPI::Structure::Block',      '{ ... }',
+		'PPI::Token::Structure',      '{',
+		'PPI::Statement',             '...',
+		'PPI::Token::Operator',       '...',
+		'PPI::Token::Structure',      '}',
+	  ],
+	  "complex signature example";
+}
+
+### TODO from ppi_token_unknown.t , deduplicate
+
+sub one_line_explain {
+	my ($data) = @_;
+	my @explain = explain $data;
+	s/\n//g for @explain;
+	return join "", @explain;
+}
+
+sub main_level_line {
+	return "" if not $TODO;
+	my @outer_final;
+	my $level = 0;
+	while ( my @outer = caller( $level++ ) ) {
+		@outer_final = @outer;
+	}
+	return "l $outer_final[2] - ";
+}
+
+sub test_document {
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+	my $args = ref $_[0] eq "ARRAY" ? shift : [];
+	my ( $code, $expected, $msg ) = @_;
+	$msg = perlstring $code if !defined $msg;
+
+	my $d      = PPI::Document->new( \$code, @{$args} ) or die explain $@;
+	my $tokens = $d->find( sub { $_[1]->significant } );
+	$tokens = [ map { ref($_), $_->content } @$tokens ];
+
+	my $ok = is_deeply( $tokens, $expected, main_level_line . $msg );
+	if ( !$ok ) {
+		diag ">>> $code -- $msg\n";
+		diag( PPI::Dumper->new($d)->string );
+		diag one_line_explain $tokens;
+		diag one_line_explain $expected;
+	}
+
+	return;
+}

--- a/xt/DepReqs.pm
+++ b/xt/DepReqs.pm
@@ -33,7 +33,7 @@ sub exclusions {
         # broken on cpan
         |Acme-VarMess|Module-Checkstyle|MooseX-Documenter|Perl-Achievements
         |Perl-Metrics|Ravenel|Test-LocalFunctions|UML-Class-Simple
-        |Test2-Plugin-DBBreak
+        |Test2-Plugin-DBBreak|Catalyst-View-EmbeddedPerl-PerRequest-ValiantRole
         # maybe broken on cpan
         |App-Grepl|App-Midgen|App-PRT|Pod-Weaver-Section-SQL
         # investigate
@@ -69,6 +69,8 @@ sub exclusions {
         | Kafka-Producer-Avro | MarpaX-Languages-PowerBuilder | Net-Async-OpenExchRates
         | Perl-Critic-Policy-PreferredModules | Pg-Corruption | PowerBuilder-DataWindow
         | Test-Kwalitee-Extra | Test-Legal | Test-Perl-Metrics-Simple
+        # https://github.com/uperl/Perl-Critic-Plicease/pull/9
+        | Perl-Critic-Plicease
     )$@x
 }
 


### PR DESCRIPTION
**For the shortest summary, see [`Changes`](https://github.com/Perl-Critic/PPI/pull/280/files) file.**

----

This is a basic implementation of feature-tracking in the parser, with most of the parts that mainly need to be expanded sketched out.

Please review and comment.

~(This breaks most of the other tests. feature_tracking.t is the only relevant test for this proof-of-concept.)~

See #273 for more details and discussion on missing details (configuration, cpan inclusion, etc.) as well as #194 for the historical ticket and discussion, and https://github.com/Perl-Critic/Perl-Critic/issues/591 for requests from the user-side.

### OPEN QUESTIONS ###

 - What tree of elements would you like to see emitted for `signature`?
 - Which `signature` features do you need PPI to recognize that currently are not?
 - What tree of elements would you like to see emitted for `try`?
 - Which `try` features do you need PPI to recognize that currently are not?
 - Which other features would you like to see parsed and into what kind of tree?
 - Which common CPAN modules should be recognized as enabling specific features?
 - What changes, if any, would you like to the custom feature includes facility?

----

TODO:

 - [ ] We also need to support the prototype keyword which is needed when signatures are enabled.
     - [ ] It's already recognized as a generic attribute. What else should we do with it? Can for the moment only think of having https://metacpan.org/pod/PPI::Statement::Sub#prototype recognize it.
     - [ ] What is its history, from which versions on is it active?
 - [x] extend the automatic recognition of perl core enabling of features
     - [ ] we need a list of core features that affect parsing
     - [x] MVP-ready, barring veto
 - [x] implement recognition of common CPAN-enabling of features, with an opt-out configuration
     - [ ] we need a preliminary list of common CPAN modules which enable parsing-relevant features
     - [x] Syntax::Keyword::Try implement, review requested
     - [x] implemented in PPI::Statement::Include::feature_mods. review requested
     - [x] MVP-ready, barring veto
 - [x] implement common configuration of home-brew-enabling of features, opt-in
     - [x] implemented in PPI::Document::new( custom_feature_includes => ... ). review requested
     - [x] MVP-ready, barring veto
 - [x] implement a callback hook in possible features-enabling elements
     - [x] implemented in PPI::Document::new( custom_feature_include_cb => ... ). review requested
     - [x] MVP-ready, barring veto
 - [x] parse signatures as perl code and create the corresponding tree elements
     - [x] MVP-ready, barring veto