### PR TITLE
split out checked document creation in test helper module

### DIFF
--- a/t/04_element.t
+++ b/t/04_element.t
@@ -7,12 +7,13 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 220 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 221 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI ();
 use PPI::Singletons qw( %_PARENT );
 use PPI::Test qw( pause );
 use Scalar::Util qw( refaddr );
+use Helper 'safe_new';
 
 my $RE_IDENTIFIER = qr/[^\W\d]\w*/;
 
@@ -439,8 +440,7 @@ SCOPE: {
 	my $k2;
 	my $k3;
 	SCOPE: {
-		my $NodeDocument = PPI::Document->new( $INC{"PPI/Node.pm"} );
-		isa_ok( $NodeDocument, 'PPI::Document' );
+		my $NodeDocument = safe_new $INC{"PPI/Node.pm"};
 		$k2 = scalar keys %_PARENT;
 		ok( $k2 > ($k1 + 3000), 'PARENT keys increases after loading document' );
 		$NodeDocument->DESTROY;

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -2,18 +2,47 @@ package Helper;
 
 use strict;
 use warnings;
-use Exporter ();
+
+use parent 'Exporter';
+use Test::More;
+
 use PPI::Document ();
 
-our @ISA = "Exporter";
-our @EXPORT_OK = qw( check_with );
+our @EXPORT_OK = qw( check_with  safe_new );
+
+=head1 safe_new @args
+
+	my $doc = safe_new \"use strict";
+
+Creates a PPI::Document object from the arguments and reports errors if
+necessary. Can be used to replace most document new calls in the tests for
+easier testing.
+
+=cut
+
+sub safe_new {
+	my $Document = PPI::Document->new(@_);
+	is( PPI::Document->errstr, '', "no errors" );
+	isa_ok $Document, 'PPI::Document';
+	return $Document;
+}
+
+=head1 check_with
+
+	check_with "1.eqm'bar';", sub {
+		is $_->child( 0 )->child( 1 )->content, "eqm'bar",
+		  "eqm' bareword after number and concat op is not mistaken for eq";
+	};
+
+Creates a document object from the given code and stores it in $_, so the sub
+passed in the second argument can quickly run tests on it.
+
+=cut
 
 sub check_with {
-    my ( $code, $checker ) = @_;
-    my $Document = PPI::Document->new( \$code );
-    is( PPI::Document->errstr, undef ) if PPI::Document->errstr;
-    local $_ = $Document;
-    $checker->();
+	my ( $code, $checker ) = @_;
+	local $_ = safe_new \$code;
+	return $checker->();
 }
 
 1;

--- a/t/ppi_token_quotelike_regexp.t
+++ b/t/ppi_token_quotelike_regexp.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 
 # Execute the tests
-use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 7 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use lib 't/lib';
 use Helper qw( check_with );

--- a/t/ppi_token_regexp.t
+++ b/t/ppi_token_regexp.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use PPI::Test::pragmas;
 
 # Execute the tests
-use Test::More tests => 7 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 11 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use lib 't/lib';
 use Helper qw( check_with );

--- a/t/ppi_token_structure.t
+++ b/t/ppi_token_structure.t
@@ -7,7 +7,7 @@ use PPI::Test::pragmas;
 use Helper qw( check_with );
 
 # Execute the tests
-use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 9 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
 
 run();
 

--- a/t/ppi_token_word.t
+++ b/t/ppi_token_word.t
@@ -7,7 +7,7 @@ use PPI::Test::pragmas;
 use Helper qw( check_with );
 
 use PPI ();
-use Test::More tests => 1762 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 1776 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 LITERAL: {
 	my @pairs = (


### PR DESCRIPTION
This primarily creates safe_new, which is PPI::Document->new, but reports an error if one happened while parsing.

Also fixes the issue that is() wasn't imported, abbreviates the Exporter usage a little (parent is more backwards-compatible, and already in the deps via Params::Util), and adds some docs.