### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: perldocker/perl-tester:5.34
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Tests
         env:
           AUTHOR_TESTING: 0
@@ -27,7 +27,7 @@ jobs:
           EXTENDED_TESTING: 1
           RELEASE_TESTING: 1
         run: auto-build-and-test-dist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: build_dir
           path: build_dir
@@ -37,8 +37,8 @@ jobs:
     container:
       image: perldocker/perl-tester:5.34
     steps:
-      - uses: actions/checkout@v2 # codecov wants to be inside a Git repository
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3 # codecov wants to be inside a Git repository
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .
@@ -77,7 +77,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .
@@ -117,7 +117,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .
@@ -154,7 +154,7 @@ jobs:
         with:
           perl-version: ${{ matrix.perl-version }}
           distribution: strawberry # this option only used on windows
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -71,6 +71,7 @@ jobs:
           - "5.30"
           - "5.32"
           - "5.34"
+          - "5.36"
     name: Perl ${{ matrix.perl-version }} on ubuntu-20.04
     steps:
       - name: set up perl
@@ -111,6 +112,7 @@ jobs:
           - "5.30"
           - "5.32"
           - "5.34"
+          - "5.36"
     name: perl ${{ matrix.perl-version }} on macos-latest
     steps:
       - name: set up perl

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.36
     steps:
       - uses: actions/checkout@v3
       - name: Run Tests
@@ -35,7 +35,7 @@ jobs:
     needs: build-job
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.36
     steps:
       - uses: actions/checkout@v3 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
- Bump versions of actions in GH test workflow
- Run CI on Perl 5.36 as well
- Build and do coverage tests on 5.36
