### PR TITLE
fix author tests: pod-no404s.t

### DIFF
--- a/lib/PPI.pm
+++ b/lib/PPI.pm
@@ -749,9 +749,10 @@ Adam Kennedy E<lt>adamk@cpan.orgE<gt>
 
 =head1 ACKNOWLEDGMENTS
 
-A huge thank you to Phase N Australia (L<http://phase-n.com/>) for
-permitting the original open sourcing and release of this distribution
-from what was originally several thousand hours of commercial work.
+A huge thank you to Phase N Australia
+(L<https://web.archive.org/web/20240304122957/http://www.phase-n.com/>) for
+permitting the original open sourcing and release of this distribution from
+what was originally several thousand hours of commercial work.
 
 Another big thank you to The Perl Foundation
 (L<http://www.perlfoundation.org/>) for funding for the final big


### PR DESCRIPTION
Unfortunately, Phase N Australia's website is gone, so link to archive.org instead.

Fixes

    xt/author/pod-no404s.t ......... # Checking http://www.perlmonks.org/index.pl?node_id=44722
    # Checking https://metacpan.org/pod/PPI
    # Checking https://github.com/Perl-Critic/PPI
    # Checking https://github.com/Perl-Critic/PPI/issues
    # Checking http://phase-n.com/
    # Checking http://www.perlfoundation.org/
    xt/author/pod-no404s.t ......... 1/95
    #   Failed test '404 test for blib/lib/PPI.pm'
    #   at …/lib/site_perl/5.42.0/Test/Pod/No404s.pm line 142.
    # Error retrieving 'http://phase-n.com/': 500 Can't connect to phase-n.com:80 (Name or service not known)
    # Checking https://web.archive.org/web/20230911221703/http://ali.as/
    xt/author/pod-no404s.t ......... 16/95 # Checking https://web.archive.org/web/https://www.unicode.org/faq/utf_bom.html#BOM
    xt/author/pod-no404s.t ......... 56/95 # Checking http://perlmonks.org/?node_id=574573
    xt/author/pod-no404s.t ......... 84/95 # Looks like you failed 1 test of 95.
    xt/author/pod-no404s.t ......... Dubious, test returned 1 (wstat 256, 0x100)