### PR TITLE
fix github actions, switch to ubuntu-latest

### DIFF
--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-job:
     name: Build distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: perldocker/perl-tester:5.38
     steps:
@@ -31,7 +31,7 @@ jobs:
           path: build_dir
   coverage-job:
     needs: build-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: perldocker/perl-tester:5.38
     steps:
@@ -50,7 +50,7 @@ jobs:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
   ubuntu-test-job:
     needs: build-job
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: true
       matrix:
@@ -71,7 +71,7 @@ jobs:
           - "5.34"
           - "5.36"
           - "5.38"
-    name: Perl ${{ matrix.perl-version }} on ubuntu-20.04
+    name: Perl ${{ matrix.perl-version }} on ubuntu-latest
     steps:
       - name: set up perl
         uses: shogo82148/actions-setup-perl@v1

--- a/.github/workflows/test-dependents.yml
+++ b/.github/workflows/test-dependents.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-and-test-job:
     name: Build distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: perldocker/perl-tester:5.36
     steps:


### PR DESCRIPTION
The ubuntu-20.04 runner no longer exists.
<https://github.com/actions/runner-images/issues/11101>:

> The Ubuntu 20.04 Actions runner image will begin deprecation on
> 2025-02-01 and will be fully unsupported by 2025-04-15