### PR TITLE
track currently active features while scanning

### DIFF
--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -111,9 +111,10 @@ Returns a new C<PPI::Lexer> object
 sub new {
 	my $class = shift->_clear;
 	bless {
-		Tokenizer => undef, # Where we store the tokenizer for a run
-		buffer    => [],    # The input token buffer
-		delayed   => [],    # The "delayed insignificant tokens" buffer
+		Tokenizer      => undef,    # Where we store the tokenizer for a run
+		buffer         => [],       # The input token buffer
+		delayed        => [],       # The "delayed insignificant tokens" buffer
+		features_stack => [],       # Stack of features in scope
 	}, $class;
 }
 
@@ -196,6 +197,10 @@ sub lex_tokenizer {
 	my $Document = PPI::Document->new;
 	ref($Document)->_setattr( $Document, %args );
 	$Tokenizer->_document($Document);
+	if (my $feat = $Document->feature_mods) {
+		push @{$self->{features_stack}}, $feat;
+		$Tokenizer->_features($feat);
+	}
 
 	# Lex the token stream into the document
 	$self->{Tokenizer} = $Tokenizer;
@@ -418,8 +423,7 @@ sub _statement {
 	# Is it a token in our known classes list
 	my $content = $Token->content;
 	my $class =
-	  ( $content eq 'try'
-		  and ( $Parent->schild(-1) || $Parent )->presumed_features->{try} )
+	  ( $content eq 'try' and ( $self->{features_stack}[-1] || {} )->{try} )
 	  ? 'PPI::Statement::Compound'
 	  : $STATEMENT_CLASSES{$content};
 
@@ -613,6 +617,20 @@ sub _statement {
 	return 'PPI::Statement';
 }
 
+sub _update_features {
+	my ( $self, $statement ) = @_;
+
+	return if ref $statement ne 'PPI::Statement::Include';
+	return unless    #
+	  my $new_features = $statement->feature_mods;
+	push @{ $self->{features_stack} }, {}
+	  if not @{ $self->{features_stack} };
+	my $current_features = $self->{features_stack}[-1];
+	$self->{Tokenizer}->_features    #
+	  ( $self->{features_stack}[-1] =
+		  { %{$current_features}, %{$new_features} } );
+}
+
 sub _lex_statement {
 	my ($self, $Statement) = @_;
 	# my $self      = shift;
@@ -641,6 +659,7 @@ sub _lex_statement {
 			$Token->isa('PPI::Token::Separator')
 		) {
 			# Rollback and end the statement
+			$self->_update_features( $Statement );
 			return $self->_rollback( $Token );
 		}
 
@@ -649,6 +668,7 @@ sub _lex_statement {
 			# Have we hit an implicit end to the statement
 			unless ( $self->_continues( $Statement, $Token ) ) {
 				# Rollback and finish the statement
+				$self->_update_features( $Statement );
 				return $self->_rollback( $Token );
 			}
 		}
@@ -662,6 +682,7 @@ sub _lex_statement {
 		# Handle normal statement terminators
 		if ( $Token->content eq ';' ) {
 			$self->_add_element( $Statement, $Token );
+			$self->_update_features( $Statement );
 			return 1;
 		}
 
@@ -684,6 +705,7 @@ sub _lex_statement {
 
 	# No, it's just the end of the file...
 	# Roll back any insignificant tokens, they'll get added at the Document level
+	$self->_update_features( $Statement );
 	$self->_rollback;
 }
 
@@ -1279,6 +1301,8 @@ sub _lex_structure {
 	# my $self      = shift;
 	# my $Structure = _INSTANCE(shift, 'PPI::Structure') or die "Bad param 1";
 
+	push @{$self->{features_stack}}, $self->{features_stack}[-1] || {};
+
 	# Start the processing loop
 	my $Token;
 	while ( ref($Token = $self->_get_token) ) {
@@ -1317,6 +1341,8 @@ sub _lex_structure {
 
 		# Is this the close of a structure ( which would be an error )
 		if ( $Token->__LEXER__closes ) {
+			pop @{$self->{features_stack}};
+
 			# Is this OUR closing structure
 			if ( $Token->content eq $Structure->start->__LEXER__opposite ) {
 				# Add any delayed tokens, and the finishing token (the ugly way)
@@ -1360,6 +1386,8 @@ sub _lex_structure {
 	unless ( defined $Token ) {
 		PPI::Exception->throw;
 	}
+
+	pop @{$self->{features_stack}};
 
 	# No, it's just the end of file.
 	# Add any insignificant trailing tokens.

--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -116,12 +116,10 @@ sub __TOKENIZER__on_char {
 		}
 
 		# Is it a nameless arg in a signature?
-		if ( $char eq ')' or $char eq '=' or $char eq ',' ) {
-			my ($has_sig) = $t->_current_token_has_signatures_active;
-			if ($has_sig) {
-				$t->{class} = $t->{token}->set_class('Symbol');
-				return $t->_finalize_token->__TOKENIZER__on_char($t);
-			}
+		my %noname = ( ')' => 1, '=' => 1, ',' => 1 );
+		if ( $noname{$char} and $t->_current_token_has_signatures_active ) {
+			$t->{class} = $t->{token}->set_class('Symbol');
+			return $t->_finalize_token->__TOKENIZER__on_char($t);
 		}
 
 		if ( $MAGIC{ $c . $char } ) {
@@ -163,12 +161,9 @@ sub __TOKENIZER__on_char {
 		}
 
 		# Is it a nameless arg in a signature?
-		if ( $char eq ')' ) {
-			my ($has_sig) = $t->_current_token_has_signatures_active;
-			if ($has_sig) {
-				$t->{class} = $t->{token}->set_class('Symbol');
-				return $t->_finalize_token->__TOKENIZER__on_char($t);
-			}
+		if ( $char eq ')' and $t->_current_token_has_signatures_active ) {
+			$t->{class} = $t->{token}->set_class('Symbol');
+			return $t->_finalize_token->__TOKENIZER__on_char($t);
 		}
 
 		if ( $MAGIC{ $c . $char } ) {
@@ -217,12 +212,9 @@ sub __TOKENIZER__on_char {
 		}
 
 		# Is it a nameless arg in a signature?
-		if ( $char eq ')' ) {
-			my ($has_sig) = $t->_current_token_has_signatures_active;
-			if ($has_sig) {
-				$t->{class} = $t->{token}->set_class('Symbol');
-				return $t->_finalize_token->__TOKENIZER__on_char($t);
-			}
+		if ( $char eq ')' and $t->_current_token_has_signatures_active ) {
+			$t->{class} = $t->{token}->set_class('Symbol');
+			return $t->_finalize_token->__TOKENIZER__on_char($t);
 		}
 
 		# Is it a magic variable?

--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -212,8 +212,9 @@ sub __TOKENIZER__on_char {
 		# 2. The one before that is the word 'sub'.
 		# 3. The one before that is a 'structure'
 
-		my ( $has_sig, @tokens ) = $t->_current_token_has_signatures_active;
-		return 'Structure' if $has_sig;
+		return 'Structure' if $t->_current_token_has_signatures_active;
+
+		my @tokens = $t->_previous_significant_tokens(3);
 
 		# A normal subroutine declaration
 		my $p1 = $tokens[1];

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -172,6 +172,7 @@ sub new {
 		token        => undef,
 		class        => 'PPI::Token::BOM',
 		zone         => 'PPI::Token::Whitespace',
+		feature_set  => undef,
 
 		# Output token buffer
 		tokens       => [],
@@ -851,23 +852,12 @@ sub __current_token_is_forced_word {
 	return '';
 }
 
-sub _current_token_has_signatures_active {
-	my ($t) = @_;
-
-	# Get at least the three previous significant tokens, and extend the
-	# retrieval range to include at least one token that can walk the
-	# already generated tree. (i.e. has a parent)
-	my ( $tokens_to_get, @tokens ) = (3);
-	while ( !@tokens or ( $tokens[-1] and !$tokens[-1]->parent ) ) {
-		@tokens = $t->_previous_significant_tokens($tokens_to_get);
-		last if @tokens < $tokens_to_get;
-		$tokens_to_get++;
-	}
-
-	my ($closest_parented_token) = grep $_->parent, @tokens;
-	$closest_parented_token ||= $t->_document || $t->_document(PPI::Document->new);
-	return $closest_parented_token->presumed_features->{signatures}, @tokens;
+sub _features {
+	my ( $self, $arg ) = @_;
+	return $arg ? $self->{feature_set} = $arg : $self->{feature_set} || {};
 }
+
+sub _current_token_has_signatures_active { shift->{feature_set}{signatures} }
 
 1;
 


### PR DESCRIPTION
... instead of repeatedly scanning backwards for all feature enabling/disabling statements every time we need to know the current feature set. In my tests, this massively speeds up parsing of big documents/source files.

Fixes #309.

Demonstration:
```perl
use v5.36;
use PPI::Document;

my $source = "use v5.36;\n";

for my $i (0 .. 399) {
    my $sub = "sub foo_$i(\$x, \$y) {\n";
    for my $j (0 .. 29) {
        $sub .= "    g(\$x->[\$y]" . join('', map ", $_", 1 .. $j) . ");\n";
    }
    $sub .= "}\n";
    $source .= "$sub\n";
}

say "parsing " . length($source) . " chars of code ...";
my $doc = PPI::Document->new(\$source);
say "done";
```

With PPI 1.284:
```
$ time perl try.pl
parsing 819901 chars of code ...
done

real    0m37.017s
user    0m36.700s
sys     0m0.310s
```

With this patch:
```
$ time perl -I"$HOME/Projects/PPI/lib" try.pl
parsing 819901 chars of code ...
done

real    0m7.387s
user    0m7.170s
sys     0m0.217s
```