### PR TITLE
Partial flush and index locations

### DIFF
--- a/lib/PPI/Document.pm
+++ b/lib/PPI/Document.pm
@@ -653,7 +653,10 @@ sub index_locations {
 	my ($first, $location) = ();
 	foreach ( 0 .. $#tokens ) {
 		my $Token = $tokens[$_];
-		next if $Token->{_location};
+		if ($Token->{_location}) {
+			$location = $Token->{_location};
+			next;
+		}
 
 		# Found the first Token without a location
 		# Calculate the new location if needed.

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -801,7 +801,7 @@ sub _flush_locations {
 			next unless refaddr($Token) == refaddr($start);
 
 			# Found the start. Flush its location
-			delete $$Token->{_location};
+			delete $Token->{_location};
 			last;
 		}
 	}

--- a/t/data/elem-loc.pl
+++ b/t/data/elem-loc.pl
@@ -1,0 +1,13 @@
+use strict; use warnings;
+
+    use Cpanel::JSON::XS 4.19 qw(decode_json);
+use Test::Script 1.27 qw(script_compiles script_runs script_stderr_is script_stderr_like);
+use Getopt::Long 2.40 qw();
+
+my $foo = encode_json( { foo => 'bar' } );
+my @foo = GetOptions();
+
+script_compiles();
+script_runs();
+script_stderr_is();
+script_stderr_like();

--- a/t/ppi_element_flush.t
+++ b/t/ppi_element_flush.t
@@ -1,0 +1,140 @@
+#!/usr/bin/perl
+
+# testing flush_locations and index_locations
+# on just part of a Document
+
+# this test scenario is directly from App::perlimports :
+# an overly long use statement in a source document is replaced with
+# one spread over multiple lines, conforming with perltidy's prerogatives
+# (to reduce friction between the tools).
+
+use lib 't/lib';
+use PPI::Test::pragmas;
+
+use PPI::Document ();
+use Test::More;
+use Helper 'safe_new';
+
+sub parse_statement {
+	my $source = shift;
+
+	# a location is a 5-element arrayref
+	my $loc = @_ > 1 ? [@_] : shift @_;
+
+	# line and pos are 1-indexed
+	my ( $line, $pos, $filen ) = @{$loc}[ 0, 1, 4 ];
+	my $text = "\n" x ( $line || 1 );
+	substr( $text, -1 ) = " " x $pos
+	  if $pos and $pos > 1;
+	substr( $text, -1 ) = $source;
+	die "couldnt parse PPI:Doc" unless    #
+	  my $doc = PPI::Document->new( \$text, readonly => 1, filename => $filen );
+	$doc->index_locations
+	  if @{$loc};
+	my $found = $doc->find_first('Statement');
+
+	# tokens belong to the document, and will disappear
+	# unless we clone them out of the doc
+	return $found->clone;
+}
+
+subtest 'partial flush' => sub {
+	my $file = "t/data/elem-loc.pl";
+	die "no document" unless    #
+	  my $Document = safe_new $file;
+
+	my $includes = $Document->find('PPI::Statement::Include');
+	my ( $include1, $include2, $include3 ) = @{$includes}[ 2, 3, 4 ];
+	is_deeply $include1->location, [ 3, 5, 5, 3, $file ],
+	  'location of 1st include';
+	is_deeply $include2->location, [ 4, 1, 1, 4, $file ],
+	  'location of 2nd include';
+	is_deeply $include3->location, [ 5, 1, 1, 5, $file ],
+	  'location of 3rd include';
+
+	my $text = <<'EOSTM';
+use Test::Script 1.27 qw(
+    script_compiles
+    script_runs
+    script_stderr_is
+    script_stderr_like
+);
+EOSTM
+	chomp $text;
+	my $replacement = parse_statement( $text, $include2->location );
+	is_deeply $replacement->location, $include2->location,
+	  'mimicked start location correctly';
+	is_deeply $replacement->last_token->location, [ 9, 2, 2, 9, $file ],
+	  'last token of replacement located correctly';
+
+	$include2->replace($replacement);
+
+	my $nextsib = $replacement->next_sibling;
+	is_deeply $nextsib->location, [ 4, 91, 91, 4, $file ],
+	  'next token location is stale';
+	is_deeply $include3->location, [ 5, 1, 1, 5, $file ],
+	  'location of 3rd include stale';
+
+	my $res = eval { $nextsib->_flush_locations };
+	local $TODO = "to be fixed";
+	is $@,   "", '_flush_locations lives';
+	is $res, 1,  '.. and returns 1';
+
+	is $nextsib->{_location}, undef, 'next token location cache deleted';
+	is $include3->first_token->{_location}, undef,
+	  '...next include stm location too';
+};
+
+subtest 'partial index' => sub {
+	my $file = "t/data/elem-loc.pl";
+	die "no document" unless    #
+	  my $Document = safe_new $file;
+
+	my $includes = $Document->find('PPI::Statement::Include');
+	my ( $include1, $include2, $include3 ) = @{$includes}[ 2, 3, 4 ];
+
+	# asking for any location, causes entire document to be indexed:
+	is_deeply $include2->location, [ 4, 1, 1, 4, $file ],
+	  'location of 2nd include';
+
+	my $text = <<'EOSTM';
+use Test::Script 1.27 qw(
+    script_compiles
+    script_runs
+    script_stderr_is
+    script_stderr_like
+);
+EOSTM
+	chomp $text;
+	my $replacement = parse_statement($text);
+	is $replacement->first_token->{_location}, undef,
+	  'replacement has no location data';
+	is $replacement->location, undef,
+	  'and it cant generate a default location when asked';
+
+	$include2->replace($replacement);
+
+	my $nextsib = $replacement->next_sibling;
+	is_deeply $nextsib->location, [ 4, 91, 91, 4, $file ],
+	  'next token location is stale';
+
+	# now the $Document has a node without location, and all
+	# subsequent elements have a stale cached location.
+
+	# a partial reindex should fix all location caches:
+	my $res = eval {
+		use warnings 'FATAL';
+		$Document->index_locations;
+	};
+	is $@,   "", 'no warning or exception from index_locations';
+	is $res, 1,  '.. and returns 1';
+
+	local $TODO = "to be fixed";
+	is_deeply $nextsib->location, [ 9, 3, 3, 9, $file ],
+	  'next token location is now fresh';
+
+	is_deeply $include3->location, [ 10, 1, 1, 10, $file ],
+	  'location of 3rd include also refreshed';
+};
+
+done_testing;

--- a/t/ppi_element_flush.t
+++ b/t/ppi_element_flush.t
@@ -128,7 +128,6 @@ EOSTM
 	is $@,   "", 'no warning or exception from index_locations';
 	is $res, 1,  '.. and returns 1';
 
-	local $TODO = "to be fixed";
 	is_deeply $nextsib->location, [ 9, 3, 3, 9, $file ],
 	  'next token location is now fresh';
 

--- a/t/ppi_element_flush.t
+++ b/t/ppi_element_flush.t
@@ -76,7 +76,6 @@ EOSTM
 	  'location of 3rd include stale';
 
 	my $res = eval { $nextsib->_flush_locations };
-	local $TODO = "to be fixed";
 	is $@,   "", '_flush_locations lives';
 	is $res, 1,  '.. and returns 1';
 


### PR DESCRIPTION
Resolves issue #325 :

`PPI:Document->index_locations` contains code to perform partial reindexing -- that is, it only recalculates locations for the first element seen to be missing one, and all subsequent elements. Existing locations at the beginning of the document [are considered still good](https://github.com/Perl-Critic/PPI/blob/1d660176d5cc33219a40fab2fc31f91ff783cbbd/lib/PPI/Document.pm#L657). This is a performance optimization. This would be really handy, for example, if one were to use e.g. a `replace` method to change part of an existing document with new source text, which can make the cached locations for all subsequent elements invalid. This behavior is undocumented in the POD.

`PPI:Document->flush_locations` can be used to flush all locations from the document; it leans on the private method PPI:Element->_flush_locations to do the job. However, the latter [contains code](https://github.com/Perl-Critic/PPI/blob/1d660176d5cc33219a40fab2fc31f91ff783cbbd/lib/PPI/Element.pm#L797) to do "partial flushing" of locations -- that is, flush the cached location from the invoking instance and all subsequent elements, but leaving prior element locations intact. This would be really handy to ensure that a later `Document->index_locations` call only does a partial reindex. This behavior is also undocumented in the POD.

Despite the existing code, neither of these intended behaviors work, because each has a minor bug. There are (obviously) no tests of these desired behaviors.

This PR fixes both bugs, and adds tests confirming the intended behavior.